### PR TITLE
make public `external`

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/embed/EmbedExternalView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/embed/EmbedExternalView.kt
@@ -14,5 +14,5 @@ class EmbedExternalView : EmbedViewUnion() {
     @SerialName("\$type")
     override var type = TYPE
 
-    private var external: EmbedExternalViewExternal? = null
+    var external: EmbedExternalViewExternal? = null
 }


### PR DESCRIPTION
I could not access `external`, so I changed it to public.