### PR TITLE
Add `FeedDefsGeneratorView` to `EmbedRecordViewUnion`

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/embed/EmbedRecordViewUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/embed/EmbedRecordViewUnion.kt
@@ -2,12 +2,14 @@ package work.socialhub.kbsky.model.bsky.embed
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.bsky.feed.FeedDefsGeneratorView
 import work.socialhub.kbsky.util.json.EmbedRecordViewPolymorphicSerializer
 
 /**
  * @see EmbedRecordViewRecord
  * @see EmbedRecordViewNotFound
  * @see EmbedRecordViewBlocked
+ * @see FeedDefsGeneratorView
  */
 @Serializable(with = EmbedRecordViewPolymorphicSerializer::class)
 abstract class EmbedRecordViewUnion {
@@ -17,4 +19,5 @@ abstract class EmbedRecordViewUnion {
     fun record() = this as? EmbedRecordViewRecord
     fun notFound() = this as? EmbedRecordViewNotFound
     fun blocked() = this as? EmbedRecordViewBlocked
+    fun generatorView() = this as? FeedDefsGeneratorView
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedDefsGeneratorView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedDefsGeneratorView.kt
@@ -1,11 +1,22 @@
 package work.socialhub.kbsky.model.bsky.feed
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.model.bsky.actor.ActorDefsProfileView
+import work.socialhub.kbsky.model.bsky.embed.EmbedRecordViewUnion
 import work.socialhub.kbsky.model.bsky.richtext.RichtextFacet
 
 @Serializable
-class FeedDefsGeneratorView {
+class FeedDefsGeneratorView : EmbedRecordViewUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.EmbedRecord + "#generatorView"
+    }
+
+    @SerialName("\$type")
+    override var type = TYPE
+
     var uri: String? = null
     var cid: String? = null
     var did: String? = null

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/EmbedRecordViewPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/EmbedRecordViewPolymorphicSerializer.kt
@@ -8,6 +8,7 @@ import work.socialhub.kbsky.model.bsky.embed.EmbedRecordViewBlocked
 import work.socialhub.kbsky.model.bsky.embed.EmbedRecordViewNotFound
 import work.socialhub.kbsky.model.bsky.embed.EmbedRecordViewRecord
 import work.socialhub.kbsky.model.bsky.embed.EmbedRecordViewUnion
+import work.socialhub.kbsky.model.bsky.feed.FeedDefsGeneratorView
 import work.socialhub.kbsky.util.json.JsonElementUtil.type
 
 object EmbedRecordViewPolymorphicSerializer :
@@ -22,6 +23,7 @@ object EmbedRecordViewPolymorphicSerializer :
             EmbedRecordViewRecord.TYPE -> EmbedRecordViewRecord.serializer()
             EmbedRecordViewNotFound.TYPE -> EmbedRecordViewNotFound.serializer()
             EmbedRecordViewBlocked.TYPE -> EmbedRecordViewBlocked.serializer()
+            FeedDefsGeneratorView.TYPE -> FeedDefsGeneratorView.serializer()
             else -> {
                 println("[Warning] Unknown Item type: $type (EmbedRecordViewUnion)")
                 Unknown.serializer()


### PR DESCRIPTION
`EmbedRecordViewUnion` に `FeedDefsGeneratorView` が現れるパターンがあったので追加しました。

see https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/record.json#L23