### PR TITLE
Fix type of FeedDefsGeneratorView

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedDefsGeneratorView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedDefsGeneratorView.kt
@@ -11,7 +11,7 @@ import work.socialhub.kbsky.model.bsky.richtext.RichtextFacet
 class FeedDefsGeneratorView : EmbedRecordViewUnion() {
 
     companion object {
-        const val TYPE = BlueskyTypes.EmbedRecord + "#generatorView"
+        const val TYPE = BlueskyTypes.FeedDefs + "#generatorView"
     }
 
     @SerialName("\$type")


### PR DESCRIPTION
すみません、#5 の修正ミスです。

https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/record.json#L23 を見ると `app.bsky.feed.defs#generatorView` なんですが  `app.bsky.embed.record#generatorView` になっていました。。。

なぜか「フィード」が表示されなくて気づいた＆直ったので今度は大丈夫だと思います。
テストケースなしで申し訳ないです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the type identifier for generator views in feeds to align with Bluesky definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->