### PR TITLE
Fix thumb as public

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/embed/EmbedExternalExternal.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/embed/EmbedExternalExternal.kt
@@ -8,5 +8,5 @@ class EmbedExternalExternal {
     lateinit var uri: String
     lateinit var title: String
     lateinit var description: String
-    private var thumb: Blob? = null
+    var thumb: Blob? = null
 }


### PR DESCRIPTION
リンクのカード情報を含めてPost投稿をする場合に、リンク先のサムネイルを含めるための thumb を設定できるようにしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the visibility of the `thumb` property in embed functionality to be public, enhancing accessibility for external usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->