### PR TITLE
Add `labels` to `FeedPost`

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolTypes.kt
@@ -22,6 +22,9 @@ object ATProtocolTypes {
     const val IdentifyResolveHandle = "com.atproto.identity.resolveHandle"
     const val IdentifyUpdateHandle = "com.atproto.identity.updateHandle"
 
+    // Label
+    const val LabelDefs = "com.atproto.label.defs"
+
     // Moderation
     const val ModerationCreateReport = "com.atproto.moderation.createReport"
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/bsky/feed/FeedPostRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/bsky/feed/FeedPostRequest.kt
@@ -4,6 +4,7 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.api.entity.share.RecordRequest
 import work.socialhub.kbsky.internal.share._InternalUtility.toJson
+import work.socialhub.kbsky.model.atproto.label.LabelDefsSelfLabels
 import work.socialhub.kbsky.model.bsky.embed.EmbedUnion
 import work.socialhub.kbsky.model.bsky.feed.FeedPost
 import work.socialhub.kbsky.model.bsky.feed.FeedPostReplyRef
@@ -16,6 +17,7 @@ class FeedPostRequest(
     lateinit var text: String
 
     var langs: List<String>? = null
+    var labels: LabelDefsSelfLabels? = null
     var facets: List<RichtextFacet>? = null
     var reply: FeedPostReplyRef? = null
     var embed: EmbedUnion? = null
@@ -25,6 +27,7 @@ class FeedPostRequest(
         return mutableMapOf<String, Any>().also {
             it.addParam("text", text)
             it.addParam("langs", toJson(langs))
+            it.addParam("labels", toJson(labels))
             it.addParam("facets", toJson(facets))
             it.addParam("reply", toJson(reply))
             it.addParam("embed", toJson(embed))
@@ -36,6 +39,7 @@ class FeedPostRequest(
         val post = FeedPost()
         post.text = text
         post.langs = langs
+        post.labels = labels
         post.facets = facets
         post.reply = reply
         post.embed = embed

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/atproto/label/LabelDefsSelfLabel.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/atproto/label/LabelDefsSelfLabel.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.model.atproto.label
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Metadata tag on an atproto record, published by the author within the record. Note that schemas should use #selfLabels, not #selfLabel.
+ */
+@Serializable
+class LabelDefsSelfLabel {
+
+    /** The short string name of the value or type of this label. */
+    lateinit var `val`: String
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/atproto/label/LabelDefsSelfLabels.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/atproto/label/LabelDefsSelfLabels.kt
@@ -1,0 +1,17 @@
+package work.socialhub.kbsky.model.atproto.label
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.ATProtocolTypes
+
+/**
+ * Metadata tags on an atproto record, published by the author within the record.
+ */
+@Serializable
+class LabelDefsSelfLabels {
+
+    @SerialName("\$type")
+    var type = ATProtocolTypes.LabelDefs + "#selfLabels"
+
+    lateinit var values: List<LabelDefsSelfLabel>
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedPost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedPost.kt
@@ -3,6 +3,7 @@ package work.socialhub.kbsky.model.bsky.feed
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.model.atproto.label.LabelDefsSelfLabels
 import work.socialhub.kbsky.model.bsky.embed.EmbedUnion
 import work.socialhub.kbsky.model.bsky.richtext.RichtextFacet
 import work.socialhub.kbsky.model.share.RecordUnion
@@ -19,6 +20,7 @@ class FeedPost : RecordUnion() {
 
     var text: String? = null
     var langs: List<String>? = null
+    var labels: LabelDefsSelfLabels? = null
     var facets: List<RichtextFacet>? = null
     var reply: FeedPostReplyRef? = null
     var embed: EmbedUnion? = null


### PR DESCRIPTION
投稿時に"sexual"などのラベルを追加するために必要だったので追加しました。

lexicon -> https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/label/defs.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced label definitions for enhanced post categorization.
	- Added support for attaching labels to posts, allowing for more descriptive and organized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->