### PR TITLE
Add `ATUri`

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/ATUri.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/ATUri.kt
@@ -1,0 +1,7 @@
+package work.socialhub.kbsky.util
+
+/**
+ * ATProtocol URI
+ * at://{did}/{recordType}/{key}
+ */
+data class ATUri(val did: String, val recordType: String, val rkey: String)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/ATUriParser.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/ATUriParser.kt
@@ -5,40 +5,44 @@ package work.socialhub.kbsky.util
  * at://{did}/{recordType}/{key}
  */
 object ATUriParser {
+
     /**
-     * Parse the URI of the record to get the DID.
+     * Parse the URI of the record.
      */
-    fun getDid(uri: String): String {
-        return uri
+    fun parse(uri: String): ATUri {
+        val array = uri
             .split("://".toRegex())
             .dropLastWhile { it.isEmpty() }
             .toTypedArray()[1]
             .split("/".toRegex())
             .dropLastWhile { it.isEmpty() }
-            .toTypedArray()[0]
+            .toTypedArray()
+
+        return ATUri(
+            array.getOrNull(0) ?: "",
+            array.getOrNull(1) ?: "",
+            array.getOrNull(2) ?: ""
+        )
+    }
+
+    /**
+     * Parse the URI of the record to get the DID.
+     */
+    fun getDid(uri: String): String {
+        return parse(uri).did
     }
 
     /**
      * Parse the URI of the record to get the RecordType.
      */
     fun getRecordType(uri: String): String {
-        return uri.split("://".toRegex())
-            .dropLastWhile { it.isEmpty() }
-            .toTypedArray()[1]
-            .split("/".toRegex())
-            .dropLastWhile { it.isEmpty() }
-            .toTypedArray()[1]
+        return parse(uri).recordType
     }
 
     /**
      * Parse the URI of the record to get the rkey.
      */
     fun getRKey(uri: String): String {
-        return uri.split("://".toRegex())
-            .dropLastWhile { it.isEmpty() }
-            .toTypedArray()[1]
-            .split("/".toRegex())
-            .dropLastWhile { it.isEmpty() }
-            .toTypedArray()[2]
+        return parse(uri).rkey
     }
 }


### PR DESCRIPTION
`ATUriParser.parse` で `ATUri` を取り出せるようにしました。

アプリ側で `getDid` と `getRKey` を同時に使うことがあり、同じ処理を2回繰り返すことになるのがどうにも気持ち悪かったので分離させていただきました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new data representation for ATProtocol URI, including components for digital identifiers and record types.
	- Enhanced URI parsing capabilities to extract and utilize specific components from ATProtocol URIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->