### PR TITLE
fix handle not lateinit

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/actor/ActorDefsProfileViewBasic.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/actor/ActorDefsProfileViewBasic.kt
@@ -9,7 +9,9 @@ import work.socialhub.kbsky.model.atproto.label.LabelDefsLabel
 @Serializable
 class ActorDefsProfileViewBasic {
     lateinit var did: String
-    lateinit var handle: String
+
+    // required but some implementations may not provide it (e.g. post.reply.root.author.handle)
+    var handle: String = ""
 
     var displayName: String? = null
     var avatar: String? = null


### PR DESCRIPTION
タイムラインに `post.reply.root.author.handle` が存在しないデータがありクラッシュしてしまうので空文字列で初期化するようにしました。