### PR TITLE
Add FeedDefsViewerState.replyDisabled

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedDefsViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/bsky/feed/FeedDefsViewerState.kt
@@ -6,4 +6,5 @@ import kotlinx.serialization.Serializable
 class FeedDefsViewerState {
     var repost: String? = null
     var like: String? = null
+    var replyDisabled: Boolean? = null
 }


### PR DESCRIPTION
ThreadGate関連ですが、ポストに対して「自分が返信不可能」を表す `post.viewer.replyDisabled` があったので追加しました。

小出しになってすみません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a setting to disable replies in the feed for certain viewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->