### PR TITLE
fix PLCDirectory

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_PLCDirectory.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_PLCDirectory.kt
@@ -19,8 +19,7 @@ class _PLCDirectory(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(uri)
-                    .path(did)
+                    .url("$uri$did")
                     .get()
             }
         }
@@ -33,8 +32,7 @@ class _PLCDirectory(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(uri)
-                    .path("$did/log")
+                    .url("$uri$did/log")
                     .get()
             }
         }


### PR DESCRIPTION
HttpRequest は .url(uri).path(did) だと path が無視されてしまうので url に変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling in directory management, resulting in more efficient and reliable access to user directories.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->