### PR TITLE
Add config and update pds endpoint feature.

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolConfig.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolConfig.kt
@@ -1,0 +1,17 @@
+package work.socialhub.kbsky
+
+import work.socialhub.kbsky.domain.Service
+
+open class ATProtocolConfig {
+
+    /**
+     * URI of the PDS.
+     */
+    var pdsUri: String = Service.BSKY_SOCIAL.uri
+
+    /**
+     * Change the URI to the PDS to which you belong when requesting a session-based API?
+     * (If you use the Chat feature, you will need to change the URI to the PDS you belong to if you turn it off)
+     */
+    var updatePdsUri: Boolean = true
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolFactory.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolFactory.kt
@@ -4,6 +4,7 @@ import work.socialhub.kbsky.internal._ATProtocol
 
 object ATProtocolFactory {
     fun instance(uri: String): ATProtocol {
-        return _ATProtocol(uri)
+        return _ATProtocol(ATProtocolConfig()
+            .also { it.pdsUri = uri })
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyConfig.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyConfig.kt
@@ -1,0 +1,3 @@
+package work.socialhub.kbsky
+
+class BlueskyConfig : ATProtocolConfig()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyFactory.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyFactory.kt
@@ -4,6 +4,11 @@ import work.socialhub.kbsky.internal._Bluesky
 
 object BlueskyFactory {
     fun instance(uri: String): Bluesky {
-        return _Bluesky(uri)
+        return _Bluesky(BlueskyConfig()
+            .also { it.pdsUri = uri })
+    }
+
+    fun instance(config: BlueskyConfig = BlueskyConfig()): Bluesky {
+        return _Bluesky(config)
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerCreateSessionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerCreateSessionResponse.kt
@@ -12,5 +12,7 @@ class ServerCreateSessionResponse {
 
     var email: String? = null
     var emailConfirmed: Boolean? = null
+    var emailAuthFactor: Boolean? = null
     var didDoc: DidDocUnion? = null
+    var active: Boolean? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerGetSessionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerGetSessionResponse.kt
@@ -10,5 +10,7 @@ class ServerGetSessionResponse {
 
     var email: String? = null
     var emailConfirmed: Boolean? = null
+    var emailAuthFactor: Boolean? = null
     var didDoc: DidDocUnion? = null
+    var active: Boolean? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerRefreshSessionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerRefreshSessionResponse.kt
@@ -11,4 +11,5 @@ class ServerRefreshSessionResponse {
     lateinit var did: String
 
     var didDoc: DidDocUnion? = null
+    var active: Boolean? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_ATProtocol.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_ATProtocol.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal
 
 import work.socialhub.kbsky.ATProtocol
+import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.api.com.atproto.IdentityResource
 import work.socialhub.kbsky.api.com.atproto.RepoResource
 import work.socialhub.kbsky.api.com.atproto.ServerResource
@@ -8,11 +9,13 @@ import work.socialhub.kbsky.internal.com.atproto._IdentityResource
 import work.socialhub.kbsky.internal.com.atproto._RepoResource
 import work.socialhub.kbsky.internal.com.atproto._ServerResource
 
-open class _ATProtocol(uri: String) : ATProtocol {
+open class _ATProtocol(
+    config: ATProtocolConfig
+) : ATProtocol {
 
-    protected val identity: IdentityResource = _IdentityResource(uri)
-    protected val server: ServerResource = _ServerResource(uri)
-    protected val repo: RepoResource = _RepoResource(uri)
+    protected val identity: IdentityResource = _IdentityResource(config)
+    protected val server: ServerResource = _ServerResource(config)
+    protected val repo: RepoResource = _RepoResource(config)
 
     /**
      * {@inheritDoc}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_Bluesky.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_Bluesky.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal
 
 import work.socialhub.kbsky.Bluesky
+import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.api.app.bsky.ActorResource
 import work.socialhub.kbsky.api.app.bsky.FeedResource
 import work.socialhub.kbsky.api.app.bsky.GraphResource
@@ -14,14 +15,16 @@ import work.socialhub.kbsky.internal.app.bsky._NotificationResource
 import work.socialhub.kbsky.internal.app.bsky._UnspeccedResource
 import work.socialhub.kbsky.internal.chat.bsky._ConvoResource
 
-class _Bluesky(uri: String) : _ATProtocol(uri), Bluesky {
+class _Bluesky(
+    config: BlueskyConfig
+) : _ATProtocol(config), Bluesky {
 
-    protected val actor: ActorResource = _ActorResource(uri)
-    protected val feed: FeedResource = _FeedResource(uri)
-    protected val graph: GraphResource = _GraphResource(uri)
-    protected val notification: NotificationResource = _NotificationResource(uri)
-    protected val undoc: UnspeccedResource = _UnspeccedResource(uri)
-    protected val convo: ConvoResource = _ConvoResource(uri)
+    protected val actor: ActorResource = _ActorResource(config)
+    protected val feed: FeedResource = _FeedResource(config)
+    protected val graph: GraphResource = _GraphResource(config)
+    protected val notification: NotificationResource = _NotificationResource(config)
+    protected val undoc: UnspeccedResource = _UnspeccedResource(config)
+    protected val convo: ConvoResource = _ConvoResource(config)
 
     /**
      * {@inheritDoc}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_ActorResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_ActorResource.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal.app.bsky
 
 import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.BlueskyTypes.ActorGetPreferences
 import work.socialhub.kbsky.BlueskyTypes.ActorGetProfile
@@ -28,7 +29,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _ActorResource(
-    private val uri: String
+    private val config: BlueskyConfig
 ) : ActorResource {
 
     override fun searchActors(
@@ -38,7 +39,7 @@ class _ActorResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, ActorSearchActors))
+                    .url(xrpc(config, ActorSearchActors))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -54,7 +55,7 @@ class _ActorResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, ActorGetProfile))
+                    .url(xrpc(config, ActorGetProfile))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -69,7 +70,7 @@ class _ActorResource(
 
         return runBlocking {
 
-            val repoResource = _RepoResource(uri)
+            val repoResource = _RepoResource(config)
 
             val original = repoResource.getRecord(
                 RepoGetRecordRequest(
@@ -118,7 +119,7 @@ class _ActorResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, ActorGetProfiles))
+                    .url(xrpc(config, ActorGetProfiles))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .also {
@@ -138,7 +139,7 @@ class _ActorResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, ActorGetPreferences))
+                    .url(xrpc(config, ActorGetPreferences))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
@@ -3,6 +3,7 @@ package work.socialhub.kbsky.internal.app.bsky
 import kotlinx.coroutines.runBlocking
 import work.socialhub.kbsky.ATProtocolTypes.RepoCreateRecord
 import work.socialhub.kbsky.ATProtocolTypes.RepoDeleteRecord
+import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetActorFeeds
 import work.socialhub.kbsky.BlueskyTypes.FeedGetActorLikes
@@ -69,7 +70,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _FeedResource(
-    private val uri: String
+    private val config: BlueskyConfig
 ) : FeedResource {
 
     override fun getAuthorFeed(
@@ -79,7 +80,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetAuthorFeed))
+                    .url(xrpc(config, FeedGetAuthorFeed))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -95,7 +96,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetLikes))
+                    .url(xrpc(config, FeedGetLikes))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -111,7 +112,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetPostThread))
+                    .url(xrpc(config, FeedGetPostThread))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -127,7 +128,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetPosts))
+                    .url(xrpc(config, FeedGetPosts))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .also { req ->
@@ -147,7 +148,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetRepostedBy))
+                    .url(xrpc(config, FeedGetRepostedBy))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -163,7 +164,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetTimeline))
+                    .url(xrpc(config, FeedGetTimeline))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -179,7 +180,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetFeed))
+                    .url(xrpc(config, FeedGetFeed))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -195,7 +196,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetListFeed))
+                    .url(xrpc(config, FeedGetListFeed))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -211,7 +212,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetActorFeeds))
+                    .url(xrpc(config, FeedGetActorFeeds))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -227,7 +228,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetActorLikes))
+                    .url(xrpc(config, FeedGetActorLikes))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -243,7 +244,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetFeedSearchPosts))
+                    .url(xrpc(config, FeedGetFeedSearchPosts))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -259,7 +260,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetFeedGenerator))
+                    .url(xrpc(config, FeedGetFeedGenerator))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -275,7 +276,7 @@ class _FeedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, FeedGetFeedGenerators))
+                    .url(xrpc(config, FeedGetFeedGenerators))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .also { req ->
@@ -302,7 +303,7 @@ class _FeedResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -325,7 +326,7 @@ class _FeedResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoDeleteRecord))
+                    .url(xrpc(config, RepoDeleteRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -348,7 +349,7 @@ class _FeedResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -371,7 +372,7 @@ class _FeedResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoDeleteRecord))
+                    .url(xrpc(config, RepoDeleteRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -394,7 +395,7 @@ class _FeedResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -417,7 +418,7 @@ class _FeedResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoDeleteRecord))
+                    .url(xrpc(config, RepoDeleteRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -443,7 +444,7 @@ class _FeedResource(
                 }
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_GraphResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_GraphResource.kt
@@ -3,6 +3,7 @@ package work.socialhub.kbsky.internal.app.bsky
 import kotlinx.coroutines.runBlocking
 import work.socialhub.kbsky.ATProtocolTypes.RepoCreateRecord
 import work.socialhub.kbsky.ATProtocolTypes.RepoDeleteRecord
+import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.BlueskyTypes.GraphBlock
 import work.socialhub.kbsky.BlueskyTypes.GraphFollow
 import work.socialhub.kbsky.BlueskyTypes.GraphGetBlocks
@@ -57,7 +58,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _GraphResource(
-    private val uri: String
+    private val config: BlueskyConfig
 ) : GraphResource {
 
     override fun follow(
@@ -74,7 +75,7 @@ class _GraphResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -97,7 +98,7 @@ class _GraphResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoDeleteRecord))
+                    .url(xrpc(config, RepoDeleteRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -113,7 +114,7 @@ class _GraphResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphGetFollowers))
+                    .url(xrpc(config, GraphGetFollowers))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -129,7 +130,7 @@ class _GraphResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphGetFollows))
+                    .url(xrpc(config, GraphGetFollows))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -145,7 +146,7 @@ class _GraphResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphGetMutes))
+                    .url(xrpc(config, GraphGetMutes))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -161,7 +162,7 @@ class _GraphResource(
         return proceedUnit {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphMuteActor))
+                    .url(xrpc(config, GraphMuteActor))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())
@@ -177,7 +178,7 @@ class _GraphResource(
         return proceedUnit {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphUnmuteActor))
+                    .url(xrpc(config, GraphUnmuteActor))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())
@@ -200,7 +201,7 @@ class _GraphResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -223,7 +224,7 @@ class _GraphResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoDeleteRecord))
+                    .url(xrpc(config, RepoDeleteRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -239,7 +240,7 @@ class _GraphResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphGetBlocks))
+                    .url(xrpc(config, GraphGetBlocks))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -260,7 +261,7 @@ class _GraphResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -274,7 +275,7 @@ class _GraphResource(
         return runBlocking {
             val listUri = request.listUri
 
-            val repoResource = _RepoResource(uri)
+            val repoResource = _RepoResource(config)
 
             val original = repoResource.getRecord(
                 RepoGetRecordRequest(
@@ -326,7 +327,7 @@ class _GraphResource(
                 rkey = rkey,
             )
 
-            _RepoResource(uri).deleteRecord(record)
+            _RepoResource(config).deleteRecord(record)
         }
     }
 
@@ -335,7 +336,7 @@ class _GraphResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphGetList))
+                    .url(xrpc(config, GraphGetList))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -349,7 +350,7 @@ class _GraphResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, GraphGetLists))
+                    .url(xrpc(config, GraphGetLists))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -370,7 +371,7 @@ class _GraphResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
@@ -391,7 +392,7 @@ class _GraphResource(
                 )
 
                 HttpRequest()
-                    .url(xrpc(uri, RepoDeleteRecord))
+                    .url(xrpc(config, RepoDeleteRecord))
                     .header("Authorization", request.bearerToken)
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_NotificationResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_NotificationResource.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal.app.bsky
 
 import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.BlueskyTypes.NotificationGetUnreadCount
 import work.socialhub.kbsky.BlueskyTypes.NotificationListNotifications
 import work.socialhub.kbsky.BlueskyTypes.NotificationUpdateSeen
@@ -18,7 +19,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _NotificationResource(
-    private val uri: String
+    private val config: BlueskyConfig
 ) : NotificationResource {
 
     override fun getUnreadCount(
@@ -28,7 +29,7 @@ class _NotificationResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, NotificationGetUnreadCount))
+                    .url(xrpc(config, NotificationGetUnreadCount))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .get()
@@ -43,7 +44,7 @@ class _NotificationResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, NotificationListNotifications))
+                    .url(xrpc(config, NotificationListNotifications))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
@@ -59,7 +60,7 @@ class _NotificationResource(
         return proceedUnit {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, NotificationUpdateSeen))
+                    .url(xrpc(config, NotificationUpdateSeen))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_UnspeccedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_UnspeccedResource.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal.app.bsky
 
 import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.BlueskyTypes.UnspeccedGetPopular
 import work.socialhub.kbsky.api.app.bsky.UnspeccedResource
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularRequest
@@ -12,7 +13,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _UnspeccedResource(
-    private val uri: String
+    private val config: BlueskyConfig
 ) : UnspeccedResource {
 
     override fun getPopular(
@@ -22,7 +23,7 @@ class _UnspeccedResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, UnspeccedGetPopular))
+                    .url(xrpc(config, UnspeccedGetPopular))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/_ConvoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/_ConvoResource.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal.chat.bsky
 
 import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.api.chat.bsky.ConvoResource
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfRequest
@@ -32,7 +33,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _ConvoResource(
-    private val uri: String
+    private val config: ATProtocolConfig
 ) : ConvoResource {
 
     override fun getConvo(
@@ -164,7 +165,7 @@ class _ConvoResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, id))
+                    .url(xrpc(config, id))
                     .header("Authorization", bearerToken)
                     .header("Atproto-Proxy", "did:web:api.bsky.chat#bsky_chat")
                     .accept(MediaType.JSON)
@@ -182,7 +183,7 @@ class _ConvoResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, id))
+                    .url(xrpc(config, id))
                     .header("Authorization", bearerToken)
                     .header("Atproto-Proxy", "did:web:api.bsky.chat#bsky_chat")
                     .accept(MediaType.JSON)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_IdentityResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_IdentityResource.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal.com.atproto
 
 import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.ATProtocolTypes.IdentifyResolveHandle
 import work.socialhub.kbsky.api.com.atproto.IdentityResource
 import work.socialhub.kbsky.api.entity.com.atproto.identity.IdentityResolveHandleRequest
@@ -12,7 +13,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _IdentityResource(
-    private val uri: String
+    private val config: ATProtocolConfig
 ) : IdentityResource {
 
     override fun resolveHandle(
@@ -22,7 +23,7 @@ class _IdentityResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, IdentifyResolveHandle))
+                    .url(xrpc(config, IdentifyResolveHandle))
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
                     .get()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_RepoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_RepoResource.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.internal.com.atproto
 
 import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.ATProtocolTypes.RepoCreateRecord
 import work.socialhub.kbsky.ATProtocolTypes.RepoDeleteRecord
 import work.socialhub.kbsky.ATProtocolTypes.RepoGetRecord
@@ -27,7 +28,7 @@ import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 
 class _RepoResource(
-    private val uri: String
+    private val config: ATProtocolConfig
 ) : RepoResource {
 
     // TODO: implement
@@ -42,7 +43,7 @@ class _RepoResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, RepoCreateRecord))
+                    .url(xrpc(config, RepoCreateRecord))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())
@@ -58,7 +59,7 @@ class _RepoResource(
         return proceedUnit {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, RepoDeleteRecord))
+                    .url(xrpc(config, RepoDeleteRecord))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())
@@ -78,7 +79,7 @@ class _RepoResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, RepoGetRecord))
+                    .url(xrpc(config, RepoGetRecord))
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
                     .get()
@@ -93,7 +94,7 @@ class _RepoResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, RepoListRecords))
+                    .url(xrpc(config, RepoListRecords))
                     .accept(MediaType.JSON)
                     .queries(request.toMap())
                     .get()
@@ -108,7 +109,7 @@ class _RepoResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, RepoPutRecord))
+                    .url(xrpc(config, RepoPutRecord))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())
@@ -124,7 +125,7 @@ class _RepoResource(
         return proceed {
             runBlocking {
                 HttpRequest()
-                    .url(xrpc(uri, RepoUploadBlob))
+                    .url(xrpc(config, RepoUploadBlob))
                     .header("Authorization", request.bearerToken)
                     .header("Content-Type", "image/jpeg")
                     .accept(MediaType.JSON)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
+import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.ATProtocolException
 import work.socialhub.kbsky.api.entity.share.ErrorResponse
 import work.socialhub.kbsky.api.entity.share.Response
@@ -73,6 +74,10 @@ object _InternalUtility {
         } catch (e: Exception) {
             throw handleError(e)
         }
+    }
+
+    fun xrpc(config: ATProtocolConfig, path: String? = null): String {
+        return xrpc(config.pdsUri, path)
     }
 
     fun xrpc(uri: String, path: String? = null): String {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/plc/DIDDetails.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/plc/DIDDetails.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.model.plc
 
 import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.domain.Service.BSKY_SOCIAL
 import work.socialhub.kbsky.model.com.atproto.server.DidDocUnion
 
 @Serializable
@@ -9,4 +10,10 @@ class DIDDetails : DidDocUnion() {
     var alsoKnownAs: List<String>? = null
     var verificationMethod: List<DIDDetailsVerificationMethod>? = null
     var service: List<DIDDetailsService>? = null
+
+    fun pdsEndpoint(): String? {
+        return service
+            ?.firstOrNull { it.id == "#atproto_pds" }
+            ?.serviceEndpoint
+    }
 }

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/AbstractTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/AbstractTest.kt
@@ -1,7 +1,6 @@
 package work.socialhub.kbsky
 
 import work.socialhub.kbsky.api.entity.share.AuthRequest
-import work.socialhub.kbsky.domain.Service.BSKY_SOCIAL
 import work.socialhub.kbsky.internal.share._InternalUtility.fromJson
 import java.io.File
 import kotlin.test.BeforeTest
@@ -37,16 +36,6 @@ open class AbstractTest {
 
         // restore session.
         readAccessJwt()
-    }
-
-    fun endpoint(): String {
-        val did = ATProtocolFactory.instance(BSKY_SOCIAL.uri)
-            .server().getSession(AuthRequest(accessJwt)).data.did
-
-        val details = PLCDirectoryFactory.instance().DIDDetails(did)
-        return details.data.service
-            ?.firstOrNull { it.id == "#atproto_pds" }
-            ?.serviceEndpoint ?: BSKY_SOCIAL.uri
     }
 
     fun getAuthRequest(): AuthRequest {

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/GetConvoTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/GetConvoTest.kt
@@ -4,7 +4,7 @@ import work.socialhub.kbsky.AbstractTest
 import work.socialhub.kbsky.BlueskyFactory
 import work.socialhub.kbsky.Printer.dump
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoRequest
-import work.socialhub.kbsky.domain.Service.OYSTER_US_EAST
+import work.socialhub.kbsky.api.entity.share.AuthRequest
 import kotlin.test.Test
 
 class GetConvoTest : AbstractTest() {
@@ -14,7 +14,12 @@ class GetConvoTest : AbstractTest() {
         val convoId = "3kvn6dlqy5v25"
 
         val convo = BlueskyFactory
-            .instance(OYSTER_US_EAST.uri)
+            .instance().also {
+                it.server()
+                    .getSession(
+                        AuthRequest(accessJwt)
+                    )
+            }
             .convo()
             .getConvo(
                 ConvoGetConvoRequest(accessJwt).also {

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/GetListConvosTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/GetListConvosTest.kt
@@ -4,6 +4,7 @@ import work.socialhub.kbsky.AbstractTest
 import work.socialhub.kbsky.BlueskyFactory
 import work.socialhub.kbsky.Printer.dump
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetListConvosRequest
+import work.socialhub.kbsky.api.entity.share.AuthRequest
 import kotlin.test.Test
 
 class GetListConvosTest : AbstractTest() {
@@ -11,7 +12,12 @@ class GetListConvosTest : AbstractTest() {
     @Test
     fun testGetListConvos() {
         val convos = BlueskyFactory
-            .instance(endpoint())
+            .instance().also {
+                it.server()
+                    .getSession(
+                        AuthRequest(accessJwt)
+                    )
+            }
             .convo()
             .getListConvos(
                 ConvoGetListConvosRequest(accessJwt)

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/ATProtocolStreamConfig.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/ATProtocolStreamConfig.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.stream
+
+import work.socialhub.kbsky.ATProtocolConfig
+import work.socialhub.kbsky.domain.Service
+
+class ATProtocolStreamConfig: ATProtocolConfig() {
+
+    /**
+     * URI of the FireHose.
+     */
+    var firehoseUri: String = Service.BSKY_NETWORK.uri
+}

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/ATProtocolStreamFactory.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/ATProtocolStreamFactory.kt
@@ -3,10 +3,21 @@ package work.socialhub.kbsky.stream
 import work.socialhub.kbsky.stream.internal.com.atproto._ATProtocolStream
 
 object ATProtocolStreamFactory {
+
     fun instance(
-        apiUri: String,
-        streamUri: String,
+        pdsUri: String,
+        firehoseUri: String,
     ): ATProtocolStream {
-        return _ATProtocolStream(apiUri, streamUri)
+        return _ATProtocolStream(
+            ATProtocolStreamConfig().also {
+                it.pdsUri = pdsUri
+                it.firehoseUri = firehoseUri
+            })
+    }
+
+    fun instance(
+        config: ATProtocolStreamConfig = ATProtocolStreamConfig(),
+    ): ATProtocolStream {
+        return _ATProtocolStream(config)
     }
 }

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/internal/com/atproto/_ATProtocolStream.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/internal/com/atproto/_ATProtocolStream.kt
@@ -3,16 +3,16 @@ package work.socialhub.kbsky.stream.internal.com.atproto
 import work.socialhub.kbsky.ATProtocol
 import work.socialhub.kbsky.internal._ATProtocol
 import work.socialhub.kbsky.stream.ATProtocolStream
+import work.socialhub.kbsky.stream.ATProtocolStreamConfig
 import work.socialhub.kbsky.stream.api.com.atproto.SyncResource
 
 class _ATProtocolStream(
-    apiUri: String,
-    streamUri: String,
+    config: ATProtocolStreamConfig
 ) : ATProtocolStream {
 
-    protected val atproto: ATProtocol = _ATProtocol(apiUri)
+    protected val atproto: ATProtocol = _ATProtocol(config)
 
-    protected val sync: SyncResource = _SyncResource(this.atproto, streamUri)
+    protected val sync: SyncResource = _SyncResource(this.atproto, config)
 
     /**
      * {@inheritDoc}

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/internal/com/atproto/_SyncResource.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/internal/com/atproto/_SyncResource.kt
@@ -3,19 +3,20 @@ package work.socialhub.kbsky.stream.internal.com.atproto
 import io.ktor.http.*
 import work.socialhub.kbsky.ATProtocol
 import work.socialhub.kbsky.ATProtocolTypes.SyncSubscribeRepos
+import work.socialhub.kbsky.stream.ATProtocolStreamConfig
 import work.socialhub.kbsky.stream.api.com.atproto.SyncResource
 import work.socialhub.kbsky.stream.api.entity.com.atproto.sync.SyncSubscribeReposRequest
 import work.socialhub.kbsky.stream.util.StreamClient
 
 class _SyncResource(
     private val atproto: ATProtocol,
-    private val uri: String
+    private val config: ATProtocolStreamConfig,
 ) : SyncResource {
 
     override fun subscribeRepos(
         request: SyncSubscribeReposRequest
     ): StreamClient {
-        val url = ("wss://" + Url(this.uri).host
+        val url = ("wss://" + Url(config.firehoseUri).host
                 + "/xrpc/" + SyncSubscribeRepos)
         return StreamClient(atproto, url, request.filter)
     }

--- a/stream/src/jvmTest/kotlin/work/socialhub/kbsky/stream/atproto/sync/SubscribeRepoTest.kt
+++ b/stream/src/jvmTest/kotlin/work/socialhub/kbsky/stream/atproto/sync/SubscribeRepoTest.kt
@@ -19,10 +19,7 @@ class SubscribeRepoTest : AbstractTest() {
     fun testSubscribeRepo() {
         runBlocking {
             val stream = ATProtocolStreamFactory
-                .instance(
-                    apiUri = BSKY_SOCIAL.uri,
-                    streamUri = BSKY_NETWORK.uri
-                )
+                .instance()
                 .sync()
                 .subscribeRepos(
                     SyncSubscribeReposRequest().also {


### PR DESCRIPTION
Add configuration and the ability to automatically update to the affiliation PDS as the Chat feature is implemented.
(When hitting Session system endpoints, replace the endpoints to the belonging PDS.)

---

設定の追加と、Chat 機能実装に合わせて、所属 PDS に自動で更新する機能を追加。
(Session 系のエンドポイントを叩く際に、所属 PDS にエンドポイントを差し替えます。)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `ATProtocolConfig` and `BlueskyConfig` for easier configuration management.
  - Added `emailAuthFactor` and `active` properties to session response classes.
  - Introduced `ATProtocolStreamConfig` for streamlined configuration in streaming contexts.

- **Improvements**
  - Unified constructor parameters across classes to use configuration objects instead of individual URIs.
  - Enhanced session creation and management with new configuration options.

- **Tests**
  - Simplified test setup in `SubscribeRepoTest` with new configuration objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->