### PR TITLE
Add viewer.knownFollowers

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -51,6 +51,7 @@ object BlueskyTypes {
     const val GraphFollow = "app.bsky.graph.follow"
     const val GraphGetFollowers = "app.bsky.graph.getFollowers"
     const val GraphGetFollows = "app.bsky.graph.getFollows"
+    const val GraphGetKnownFollowers = "app.bsky.graph.getKnownFollowers"
     const val GraphGetMutes = "app.bsky.graph.getMutes"
     const val GraphMuteActor = "app.bsky.graph.muteActor"
     const val GraphUnmuteActor = "app.bsky.graph.unmuteActor"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
@@ -18,6 +18,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowersRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowersResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowsResponse
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetKnownFollowersRequest
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetKnownFollowersResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListsRequest
@@ -64,6 +66,13 @@ interface GraphResource {
     fun getFollows(
         request: GraphGetFollowsRequest
     ): Response<GraphGetFollowsResponse>
+
+    /**
+     * Enumerates accounts which follow a specified account (actor) and are followed by the viewer.
+     */
+    fun getKnownFollowers(
+        request: GraphGetKnownFollowersRequest
+    ): Response<GraphGetKnownFollowersResponse>
 
     /**
      * Who does the viewer mute?

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersRequest.kt
@@ -1,0 +1,21 @@
+package work.socialhub.kbsky.api.entity.app.bsky.graph
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+
+class GraphGetKnownFollowersRequest(
+    accessJwt: String
+) : AuthRequest(accessJwt), MapRequest {
+
+    var actor: String? = null
+    var limit: Int? = null
+    var cursor: String? = null
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("actor", actor)
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersResponse.kt
@@ -1,0 +1,11 @@
+package work.socialhub.kbsky.api.entity.app.bsky.graph
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
+
+@Serializable
+class GraphGetKnownFollowersResponse {
+    var cursor: String? = null
+    lateinit var subject: ActorDefsProfileView
+    lateinit var followers: List<ActorDefsProfileView>
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_GraphResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_GraphResource.kt
@@ -9,6 +9,7 @@ import work.socialhub.kbsky.BlueskyTypes.GraphFollow
 import work.socialhub.kbsky.BlueskyTypes.GraphGetBlocks
 import work.socialhub.kbsky.BlueskyTypes.GraphGetFollowers
 import work.socialhub.kbsky.BlueskyTypes.GraphGetFollows
+import work.socialhub.kbsky.BlueskyTypes.GraphGetKnownFollowers
 import work.socialhub.kbsky.BlueskyTypes.GraphGetList
 import work.socialhub.kbsky.BlueskyTypes.GraphGetLists
 import work.socialhub.kbsky.BlueskyTypes.GraphGetMutes
@@ -35,6 +36,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowersRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowersResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetFollowsResponse
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetKnownFollowersRequest
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetKnownFollowersResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListsRequest
@@ -131,6 +134,22 @@ class _GraphResource(
             runBlocking {
                 HttpRequest()
                     .url(xrpc(config, GraphGetFollows))
+                    .header("Authorization", request.bearerToken)
+                    .accept(MediaType.JSON)
+                    .queries(request.toMap())
+                    .get()
+            }
+        }
+    }
+
+    override fun getKnownFollowers(
+        request: GraphGetKnownFollowersRequest
+    ): Response<GraphGetKnownFollowersResponse> {
+
+        return proceed {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, GraphGetKnownFollowers))
                     .header("Authorization", request.bearerToken)
                     .accept(MediaType.JSON)
                     .queries(request.toMap())

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsKnownFollowers.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsKnownFollowers.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.model.app.bsky.actor
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class ActorDefsKnownFollowers {
+
+    val count: Int = 0
+
+    lateinit var followers: List<ActorDefsProfileViewBasic>
+
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsViewerState.kt
@@ -16,4 +16,6 @@ class ActorDefsViewerState {
 
     /** at-uri  */
     var followedBy: String? = null
+
+    val knownFollowers: ActorDefsKnownFollowers? = null
 }


### PR DESCRIPTION
Add `viewer.knownFollowers` and `getKnownFollowers` to display followers known by viewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new model to manage known followers, enhancing data representation and user interactions.
	- Added the ability to track known followers within the viewer state, improving follower-related information visibility.
	- Expanded API capabilities with a new method to retrieve known followers, facilitating more detailed follower relationship insights.
	- Implemented new request and response structures for managing known follower queries, streamlining data handling for follower interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->