### PR TITLE
Add quote count & getQuotes

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -32,6 +32,7 @@ object BlueskyTypes {
     const val FeedGetLikes = "app.bsky.feed.getLikes"
     const val FeedGetPostThread = "app.bsky.feed.getPostThread"
     const val FeedGetPosts = "app.bsky.feed.getPosts"
+    const val FeedGetQuotes = "app.bsky.feed.getQuotes"
     const val FeedGetRepostedBy = "app.bsky.feed.getRepostedBy"
     const val FeedGetTimeline = "app.bsky.feed.getTimeline"
     const val FeedLike = "app.bsky.feed.like"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
@@ -23,6 +23,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostThreadRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostThreadResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostsResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesRequest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineRequest
@@ -74,7 +76,14 @@ interface FeedResource {
     ): Response<FeedGetPostsResponse>
 
     /**
-     *
+     * Get a list of quotes for a given post.
+     */
+    fun getQuotes(
+        request: FeedGetQuotesRequest
+    ): Response<FeedGetQuotesResponse>
+
+    /**
+     * Get a list of reposts for a given post.
      */
     fun getRepostedBy(
         request: FeedGetRepostedByRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesRequest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+
+class FeedGetQuotesRequest(
+    accessJwt: String
+) : AuthRequest(accessJwt), MapRequest {
+
+    lateinit var uri: String
+
+    var cid: String? = null
+    var limit: Int? = null
+    var cursor: String? = null
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("uri", uri)
+            it.addParam("cid", cid)
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesResponse.kt
@@ -1,0 +1,16 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
+
+@Serializable
+class FeedGetQuotesResponse {
+
+    lateinit var uri: String
+
+    var cid: String? = null
+
+    var cursor: String? = null
+
+    lateinit var posts: List<FeedDefsPostView>
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
@@ -16,6 +16,7 @@ import work.socialhub.kbsky.BlueskyTypes.FeedGetLikes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetListFeed
 import work.socialhub.kbsky.BlueskyTypes.FeedGetPostThread
 import work.socialhub.kbsky.BlueskyTypes.FeedGetPosts
+import work.socialhub.kbsky.BlueskyTypes.FeedGetQuotes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetRepostedBy
 import work.socialhub.kbsky.BlueskyTypes.FeedGetTimeline
 import work.socialhub.kbsky.BlueskyTypes.FeedLike
@@ -45,6 +46,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostThreadRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostThreadResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostsResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesRequest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineRequest
@@ -136,6 +139,22 @@ class _FeedResource(
                             req.query("uris", it)
                         }
                     }
+                    .get()
+            }
+        }
+    }
+
+    override fun getQuotes(
+        request: FeedGetQuotesRequest
+    ): Response<FeedGetQuotesResponse> {
+
+        return proceed {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, FeedGetQuotes))
+                    .header("Authorization", request.bearerToken)
+                    .accept(MediaType.JSON)
+                    .queries(request.toMap())
                     .get()
             }
         }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
@@ -16,6 +16,7 @@ class FeedDefsPostView {
     var replyCount: Int? = null
     var repostCount: Int? = null
     var likeCount: Int? = null
+    var quoteCount: Int? = null
     var indexedAt: String? = null
     var viewer: FeedDefsViewerState? = null
     var labels: List<LabelDefsLabel>? = null


### PR DESCRIPTION
Added `post.quoteCount` and `feed.getQuotes`.

see [quoteCount](https://github.com/bluesky-social/atproto/blob/ec2e426e3273081b78841df91d69f87b6391bc9d/lexicons/app/bsky/feed/defs.json#L28), [getQuotes](https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/getQuotes.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint for retrieving quotes within the Bluesky feed.
	- Added functionality to fetch quotes associated with specific posts.
	- Implemented a new data structure to handle API requests and responses for quotes.

- **Enhancements**
	- Updated the data model to include a property for counting quotes linked to posts. 

These changes expand the interaction capabilities within the application, allowing users to engage more deeply with content on the Bluesky platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->