### PR TITLE
Update to Kotlin 20.0.20 and ignore checking of base64 padding

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/AuthRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/AuthRequest.kt
@@ -19,7 +19,7 @@ open class AuthRequest(
                 .toTypedArray()[1]
 
             @OptIn(ExperimentalEncodingApi::class)
-            val decodedJson = Base64.decode(encodedJson)
+            val decodedJson = Base64.Default.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL).decode(encodedJson)
             return fromJson<Jwt>(decodedJson.decodeToString()).sub
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.10"
+kotlin = "2.0.20"
 kotest = "5.9.1"
 
 [libraries]


### PR DESCRIPTION
`Kotlin 2.0.20` にすると Base64 のデコード時に padding (末尾に = を0～2個付けるアレ) が厳密にチェックされるようになりました。

`accessJwt` から `did` を取り出すところでユーザーによっては(つまりパディングが付く2/3の確率で)失敗するので、このチェックを行わないように修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved Base64 decoding logic to enhance compatibility with various encoded strings.

- **Chores**
	- Updated Kotlin version from 2.0.10 to 2.0.20, potentially introducing new features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->