### PR TITLE
Add EmbedRecordViewDetached

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewDetached.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewDetached.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.model.app.bsky.embed
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+class EmbedRecordViewDetached : EmbedRecordViewUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.EmbedRecord + "#viewDetached"
+    }
+
+    @SerialName("\$type")
+    override var type = TYPE
+
+    var uri: String? = null
+
+    var detached: Boolean = true
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewUnion.kt
@@ -10,6 +10,7 @@ import work.socialhub.kbsky.util.json.EmbedRecordViewPolymorphicSerializer
  * @see EmbedRecordViewRecord
  * @see EmbedRecordViewNotFound
  * @see EmbedRecordViewBlocked
+ * @see EmbedRecordViewDetached
  * @see FeedDefsGeneratorView
  * @see GraphDefsListView
  */
@@ -21,6 +22,7 @@ abstract class EmbedRecordViewUnion {
     val asRecord get() = this as? EmbedRecordViewRecord
     val asNotFound get() = this as? EmbedRecordViewNotFound
     val asBlocked get() = this as? EmbedRecordViewBlocked
+    val asDetached get() = this as? EmbedRecordViewDetached
     val asGeneratorView get() = this as? FeedDefsGeneratorView
     val asListView get() = this as? GraphDefsListView
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/EmbedRecordViewPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/EmbedRecordViewPolymorphicSerializer.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedRecordViewBlocked
+import work.socialhub.kbsky.model.app.bsky.embed.EmbedRecordViewDetached
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedRecordViewNotFound
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedRecordViewRecord
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedRecordViewUnion
@@ -24,6 +25,7 @@ object EmbedRecordViewPolymorphicSerializer :
             EmbedRecordViewRecord.TYPE -> EmbedRecordViewRecord.serializer()
             EmbedRecordViewNotFound.TYPE -> EmbedRecordViewNotFound.serializer()
             EmbedRecordViewBlocked.TYPE -> EmbedRecordViewBlocked.serializer()
+            EmbedRecordViewDetached.TYPE -> EmbedRecordViewDetached.serializer()
             FeedDefsGeneratorView.TYPE -> FeedDefsGeneratorView.serializer()
             GraphDefsListView.TYPE -> GraphDefsListView.serializer()
             else -> {


### PR DESCRIPTION
Bluesky 1.90 の新機能「引用の切り離し」で、引用を切り離されたポストが viewDetached に置き換わるのでこれの対応を行いました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `EmbedRecordViewDetached` class to enhance embed record management.
	- Added functionality to the `EmbedRecordViewUnion` class to support type casting to `EmbedRecordViewDetached`.
	- Enhanced the `EmbedRecordViewPolymorphicSerializer` to handle the new `EmbedRecordViewDetached` type for improved serialization.

- **Documentation**
	- Updated documentation comments to reference the new `EmbedRecordViewDetached` class for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->