### PR TITLE
Add ActorDefsSavedFeedsPrefV2

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPreferencesUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPreferencesUnion.kt
@@ -9,6 +9,7 @@ import work.socialhub.kbsky.util.json.ActorDefsPreferencesPolymorphicSerializer
  * @see ActorDefsAdultContentPref
  * @see ActorDefsContentLabelPref
  * @see ActorDefsSavedFeedsPref
+ * @see ActorDefsSavedFeedsPrefV2
  * @see ActorDefsFeedViewPref
  * @see ActorDefsThreadViewPref
  */
@@ -21,6 +22,7 @@ abstract class ActorDefsPreferencesUnion {
     val asAdultContentPref get() = this as? ActorDefsAdultContentPref
     val asContentLabelPref get() = this as? ActorDefsContentLabelPref
     val asSavedFeedsPref get() = this as? ActorDefsSavedFeedsPref
+    val asSavedFeedsPrefV2 get() = this as? ActorDefsSavedFeedsPrefV2
     val asFeedViewPref get() = this as? ActorDefsFeedViewPref
     val asThreadViewPref get() = this as? ActorDefsThreadViewPref
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeed.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeed.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.model.app.bsky.actor
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class ActorDefsSavedFeed(
+    val id: String,
+    // knownValues: ['feed', 'list', 'timeline']
+    val type: String,
+    val value: String,
+    val pinned: Boolean,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeedsPrefV2.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeedsPrefV2.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.model.app.bsky.actor
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+class ActorDefsSavedFeedsPrefV2 : ActorDefsPreferencesUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ActorDefs + "#savedFeedsPrefV2"
+    }
+
+    @SerialName("\$type")
+    override var type = TYPE
+
+    lateinit var items: List<ActorDefsSavedFeed>
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ActorDefsPreferencesPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ActorDefsPreferencesPolymorphicSerializer.kt
@@ -10,6 +10,7 @@ import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsFeedViewPref
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsPersonalDetailsPref
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsPreferencesUnion
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsSavedFeedsPref
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsSavedFeedsPrefV2
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsThreadViewPref
 import work.socialhub.kbsky.util.json.JsonElementUtil.type
 
@@ -26,6 +27,7 @@ object ActorDefsPreferencesPolymorphicSerializer :
             ActorDefsAdultContentPref.TYPE -> ActorDefsAdultContentPref.serializer()
             ActorDefsContentLabelPref.TYPE -> ActorDefsContentLabelPref.serializer()
             ActorDefsSavedFeedsPref.TYPE -> ActorDefsSavedFeedsPref.serializer()
+            ActorDefsSavedFeedsPrefV2.TYPE -> ActorDefsSavedFeedsPrefV2.serializer()
             ActorDefsFeedViewPref.TYPE -> ActorDefsFeedViewPref.serializer()
             ActorDefsThreadViewPref.TYPE -> ActorDefsThreadViewPref.serializer()
             else -> {

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/actor/GetPreferencesTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/actor/GetPreferencesTest.kt
@@ -6,6 +6,7 @@ import work.socialhub.kbsky.api.entity.app.bsky.actor.ActorGetPreferencesRequest
 import work.socialhub.kbsky.domain.Service.BSKY_SOCIAL
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsAdultContentPref
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsSavedFeedsPref
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsSavedFeedsPrefV2
 import kotlin.test.Test
 
 class GetPreferencesTest : AbstractTest() {
@@ -27,6 +28,10 @@ class GetPreferencesTest : AbstractTest() {
 
             if (s is ActorDefsSavedFeedsPref) {
                 s.saved.forEach { println(it) }
+            }
+
+            if (s is ActorDefsSavedFeedsPrefV2) {
+                s.items.forEach { println(it) }
             }
         }
     }


### PR DESCRIPTION
フィード一覧が savedFeedsPrefV2 に変わっていたので対応しました

see https://github.com/bluesky-social/atproto/commit/b9b7c582199d57d2fe0af8af5c8c411ed34f5b9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new preference type for saved feeds, enhancing user preference management.
	- Added support for handling multiple saved feeds within the application.

- **Bug Fixes**
	- Improved serialization logic to accommodate new saved feeds preferences.

- **Tests**
	- Expanded test coverage to validate the behavior of the new saved feeds preference structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->