### PR TITLE
Add ATProtocolException.status

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolException.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolException.kt
@@ -5,12 +5,13 @@ import work.socialhub.kbsky.api.entity.share.ErrorResponse
 open class ATProtocolException(
     message: String?,
     exception: Exception?,
+    val status: Int?,
 ) : RuntimeException(
     message,
     exception,
 ) {
     var response: ErrorResponse? = null
 
-    constructor(message: String?) : this(message, null)
-    constructor(exception: Exception?) : this(null, exception)
+    constructor(message: String?) : this(message, null, null)
+    constructor(exception: Exception?) : this(null, exception, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
@@ -50,7 +50,8 @@ object _InternalUtility {
 
             throw handleError(
                 exception = null,
-                body = response.stringBody
+                body = response.stringBody,
+                status = response.status
             )
         } catch (e: Exception) {
             throw handleError(e)
@@ -69,7 +70,8 @@ object _InternalUtility {
 
             throw handleError(
                 exception = null,
-                body = response.stringBody
+                body = response.stringBody,
+                status = response.status
             )
         } catch (e: Exception) {
             throw handleError(e)
@@ -95,6 +97,7 @@ object _InternalUtility {
     fun handleError(
         exception: Exception?,
         body: String? = null,
+        status: Int? = null
     ): RuntimeException {
 
         // ATProtocolException is already handled.
@@ -107,6 +110,7 @@ object _InternalUtility {
             return ATProtocolException(
                 message = response.message,
                 exception = exception,
+                status = status
             ).also { it.response = response }
         }
 

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/util/ErrorTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/util/ErrorTest.kt
@@ -21,6 +21,7 @@ class ErrorTest : AbstractTest() {
                 )
 
         } catch (e: ATProtocolException) {
+            println(e.status)
             println(e.response?.message)
             println(e.response?.error)
         }


### PR DESCRIPTION
アプリ側でエラー時のHTTP Statusを見たい場合があるので追加しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced exception handling with the addition of a status parameter for more detailed error reporting.
	- Improved error handling logic to capture response status during error occurrences.

- **Bug Fixes**
	- Updated error handling to provide richer context for debugging by including status information in exceptions.

- **Tests**
	- Added output for exception status in error handling tests to improve debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->