### PR TITLE
add createdAt on profiles

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileView.kt
@@ -14,6 +14,7 @@ class ActorDefsProfileView {
     var avatar: String? = null
     var associated: ActorDefsProfileAssociated? = null
     var indexedAt: String? = null
+    var createdAt: String? = null
     var viewer: ActorDefsViewerState? = null
     var labels: List<LabelDefsLabel>? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewBasic.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewBasic.kt
@@ -18,4 +18,5 @@ class ActorDefsProfileViewBasic {
     var viewer: ActorDefsViewerState? = null
     var associated: ActorDefsProfileAssociated? = null
     var labels: List<LabelDefsLabel>? = null
+    var createdAt: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewDetailed.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewDetailed.kt
@@ -18,6 +18,7 @@ open class ActorDefsProfileViewDetailed {
     var postsCount: Int? = null
     var associated: ActorDefsProfileAssociated? = null
     var indexedAt: String? = null
+    var createdAt: String? = null
     var viewer: ActorDefsViewerState? = null
     var labels: List<LabelDefsLabel>? = null
 }


### PR DESCRIPTION
プロフィールに登録日時が追加されていました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `createdAt` property to profile view classes, allowing for the display of profile creation timestamps.
- **Bug Fixes**
	- Enhanced data structure for profile views with additional temporal context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->