### PR TITLE
Support pinned post

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorUpdateProfileRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorUpdateProfileRequest.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.api.entity.app.bsky.actor
 
 import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
 import work.socialhub.kbsky.model.share.Blob
 
 class ActorUpdateProfileRequest(
@@ -10,5 +11,8 @@ class ActorUpdateProfileRequest(
     val avatar: Blob? = null,
     val banner: Blob? = null,
     // set true if you want to clear the avatar
-    val clearBanner: Boolean = false
+    val clearBanner: Boolean = false,
+    val pinnedPost: RepoStrongRef? = null,
+    // set true if you want to clear the pinned post
+    val clearPinnedPost: Boolean = false,
 ) : AuthRequest(accessJwt)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
@@ -21,12 +21,15 @@ class FeedGetAuthorFeedRequest(
 
     var filter: Filter? = null
 
+    var includePins: Boolean = false
+
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {
             it.addParam("actor", actor)
             it.addParam("limit", limit)
             it.addParam("cursor", cursor)
             it.addParam("filter", filter?.value)
+            it.addParam("includePins", includePins)
         }
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_ActorResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_ActorResource.kt
@@ -74,7 +74,7 @@ class _ActorResource(
 
             val original = repoResource.getRecord(
                 RepoGetRecordRequest(
-                    repo = request.did!!,
+                    repo = request.did,
                     collection = BlueskyTypes.ActorProfile,
                     rkey = "self"
                 )
@@ -93,13 +93,19 @@ class _ActorResource(
                 } else {
                     it.banner = request.banner ?: originalActorProfile.banner
                 }
+
+                if (request.clearPinnedPost) {
+                    it.pinnedPost = null
+                } else {
+                    it.pinnedPost = request.pinnedPost ?: originalActorProfile.pinnedPost
+                }
             }
 
             val r = repoResource.putRecord(
                 RepoPutRecordRequest(
                     collection = BlueskyTypes.ActorProfile,
                     accessJwt = request.accessJwt,
-                    repo = request.did!!,
+                    repo = request.did,
                     rkey = "self",
                     record = modifiedActorProfileRecord
                 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewDetailed.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewDetailed.kt
@@ -2,6 +2,8 @@ package work.socialhub.kbsky.model.app.bsky.actor
 
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
+import work.socialhub.kbsky.util.json.PinnedPostSerializer
 
 @Serializable
 open class ActorDefsProfileViewDetailed {
@@ -20,4 +22,10 @@ open class ActorDefsProfileViewDetailed {
     var indexedAt: String? = null
     var viewer: ActorDefsViewerState? = null
     var labels: List<LabelDefsLabel>? = null
+
+    // In Japan, many clients are using "string type declaration" for pinnedPost field,
+    // like "pinnedPost": "at://did:plc:xxx".
+    // Parse the string type declaration as uri of RepoStrongRef by using [PinnedPostSerializer]
+    @Serializable(with = PinnedPostSerializer::class)
+    var pinnedPost: RepoStrongRef? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorProfile.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorProfile.kt
@@ -3,6 +3,7 @@ package work.socialhub.kbsky.model.app.bsky.actor
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
 import work.socialhub.kbsky.model.share.Blob
 import work.socialhub.kbsky.model.share.RecordUnion
 
@@ -20,4 +21,5 @@ class ActorProfile : RecordUnion() {
     var description: String? = null
     var avatar: Blob? = null
     var banner: Blob? = null
+    var pinnedPost: RepoStrongRef? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsFeedViewPost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsFeedViewPost.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 class FeedDefsFeedViewPost {
     lateinit var post: FeedDefsPostView
     var reply: FeedDefsReplyRef? = null
-    var reason: FeedDefsReasonRepost? = null
+    var reason: FeedDefsReasonUnion? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonPin.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonPin.kt
@@ -3,18 +3,14 @@ package work.socialhub.kbsky.model.app.bsky.feed
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
-import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewBasic
 
 @Serializable
-class FeedDefsReasonRepost : FeedDefsReasonUnion() {
+class FeedDefsReasonPin : FeedDefsReasonUnion() {
 
     companion object {
-        val TYPE = BlueskyTypes.FeedDefs + "#reasonRepost"
+        val TYPE = BlueskyTypes.FeedDefs + "#reasonPin"
     }
 
     @SerialName("\$type")
     override var type = TYPE
-
-    var by: ActorDefsProfileViewBasic? = null
-    var indexedAt: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonUnion.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.model.app.bsky.feed
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.util.json.FeedDefsReasonPolymorphicSerializer
+
+/**
+ * @see FeedDefsReasonRepost
+ * @see FeedDefsReasonPin
+ */
+@Serializable(with = FeedDefsReasonPolymorphicSerializer::class)
+abstract class FeedDefsReasonUnion {
+    @SerialName("\$type")
+    abstract var type: String
+
+    val asReasonRepost get() = this as? FeedDefsReasonRepost
+    val asReasonPin get() = this as? FeedDefsReasonPin
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsViewerState.kt
@@ -8,4 +8,5 @@ class FeedDefsViewerState {
     var like: String? = null
     var replyDisabled: Boolean? = null
     var embeddingDisabled: Boolean? = null
+    var pinned: Boolean? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/FeedDefsReasonPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/FeedDefsReasonPolymorphicSerializer.kt
@@ -1,0 +1,34 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsReasonPin
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsReasonRepost
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsReasonUnion
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object FeedDefsReasonPolymorphicSerializer :
+    JsonContentPolymorphicSerializer<FeedDefsReasonUnion>(
+        FeedDefsReasonUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<FeedDefsReasonUnion> {
+        return when (val type = element.type()) {
+            FeedDefsReasonRepost.TYPE -> FeedDefsReasonRepost.serializer()
+            FeedDefsReasonPin.TYPE -> FeedDefsReasonPin.serializer()
+            else -> {
+                println("[Warning] Unknown Item type: $type (FeedDefsReasonUnion)")
+                Unknown.serializer()
+            }
+        }
+    }
+
+    @Serializable
+    class Unknown : FeedDefsReasonUnion() {
+        override var type: String = "unknown"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/PinnedPostSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/PinnedPostSerializer.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonTransformingSerializer
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
+
+object PinnedPostSerializer :
+    JsonTransformingSerializer<RepoStrongRef>(
+        RepoStrongRef.serializer()
+    ) {
+
+    override fun transformDeserialize(
+        element: JsonElement
+    ): JsonElement {
+        return if (element is JsonObject) {
+            element
+        } else {
+            // fallback for old pinned post format
+            JsonObject(mapOf("uri" to element, "cid" to JsonPrimitive("")))
+        }
+    }
+}


### PR DESCRIPTION
ポストの固定に対応しました


- Add `pinnedPost` to `ActorDefsProfileViewDetailed` with fallbacks
  - プロフィール詳細に pinnedPost を追加しました。
  - 日本のいくつかのクライアントが独自に対応していた `pinnedPost` は形式が違うので落ちないようにカスタムシリアライザを追加しています。
- Change `FeedDefsFeedViewPost.reason` to `FeedDefsReasonUnion` from `FeedDefsReasonRepost` to support `reasonPin`
  - post.reason がこれまではリポスト固定でしたが「ピン」のパターンも増えたので Union を追加しています。けっこう既存アプリに影響があります。
- Add `includePins` parameter to `getAuthorFeed`
  - ユーザーのポスト一覧取得時に固定ポストを含めることができるようになりました。
- Add ability to set/unset pinned post to/from profile
  - プロフィール編集機能の一部としてポストの固定ができるようになりました。
- Add `post.viewer.pinned` flag
  - 自分のポスト一覧内に「このポストは固定済み」と識別できるフラグが付いています。固定解除するときの判定等に使えます。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Users can now manage pinned posts directly from their profile updates with new options to pin or clear pinned posts.
	- The author feed request now includes an option to retrieve pinned posts.

- **Enhancements**
	- The viewer state now indicates whether a feed is pinned.
	- New serialization support for different feed reasons, including repost and pin reasons.

- **Bug Fixes**
	- Improved handling of pinned post attributes during profile updates. 

These changes enhance user experience by providing more control over content visibility and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->