### PR TITLE
parse OAuth error message (error_description)

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/ErrorResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/ErrorResponse.kt
@@ -1,5 +1,6 @@
 package work.socialhub.kbsky.api.entity.share
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -7,7 +8,16 @@ class ErrorResponse {
     var message: String = ""
     lateinit var error: String
 
+    // for OAuth
+    @SerialName("error_description")
+    var errorDescription: String = ""
+
     fun messageForDisplay(): String {
-        return message.ifBlank { error }
+        return if (errorDescription.isNotEmpty()) {
+            // OAuth error
+            "$error: $errorDescription"
+        } else {
+            message.ifBlank { error }
+        }
     }
 }


### PR DESCRIPTION
OAuth のエラーメッセージを `ATProtocolException.message` で参照できるように修正しました。

現状では `ATProtocolException.body` から自力でパースする必要があります。

`OAuth` の場合は `OAuthException` のようなものを別途用意する形でもいいかもしれません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with a new property for more informative error messages.
	- Improved display logic prioritizes detailed error descriptions for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->