### PR TITLE
Bump cryptography-kotlin from 0.3.1 to 0.4.0

### DIFF
--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/OAuthProvider.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/OAuthProvider.kt
@@ -1,9 +1,10 @@
 package work.socialhub.kbsky.auth
 
 import dev.whyoleg.cryptography.CryptographyProvider
-import dev.whyoleg.cryptography.algorithms.asymmetric.EC
-import dev.whyoleg.cryptography.algorithms.asymmetric.ECDSA
-import dev.whyoleg.cryptography.algorithms.digest.SHA256
+import dev.whyoleg.cryptography.algorithms.EC
+import dev.whyoleg.cryptography.algorithms.ECDSA
+import dev.whyoleg.cryptography.algorithms.ECDSA.SignatureFormat
+import dev.whyoleg.cryptography.algorithms.SHA256
 import io.ktor.http.Url
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.auth.helper.OAuthHelper
@@ -68,14 +69,15 @@ class OAuthProvider(
             publicKeyWAffineY = publicKeyXY.second,
             sign = { jwtMessage ->
 
-                val privateKey = CryptographyProvider.Default.get(ECDSA)
+                val provider = CryptographyProvider.Default
+                val privateKey = provider.get(ECDSA)
                     .privateKeyDecoder(EC.Curve.P256)
-                    .decodeFromBlocking(
+                    .decodeFromByteArrayBlocking(
                         EC.PrivateKey.Format.DER,
                         Base64.decode(context.privateKey!!)
                     )
 
-                privateKey.signatureGenerator(SHA256)
+                privateKey.signatureGenerator(SHA256, SignatureFormat.RAW)
                     .generateSignatureBlocking(jwtMessage.encodeToByteArray())
             }
         )

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/helper/OAuthHelper.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/helper/OAuthHelper.kt
@@ -1,7 +1,7 @@
 package work.socialhub.kbsky.auth.helper
 
 import dev.whyoleg.cryptography.CryptographyProvider
-import dev.whyoleg.cryptography.algorithms.digest.SHA256
+import dev.whyoleg.cryptography.algorithms.SHA256
 import io.ktor.utils.io.core.toByteArray
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.buildJsonObject

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
@@ -1,9 +1,10 @@
 package work.socialhub.kbsky.auth.internal
 
 import dev.whyoleg.cryptography.CryptographyProvider
-import dev.whyoleg.cryptography.algorithms.asymmetric.EC
-import dev.whyoleg.cryptography.algorithms.asymmetric.ECDSA
-import dev.whyoleg.cryptography.algorithms.digest.SHA256
+import dev.whyoleg.cryptography.algorithms.EC
+import dev.whyoleg.cryptography.algorithms.ECDSA
+import dev.whyoleg.cryptography.algorithms.ECDSA.SignatureFormat
+import dev.whyoleg.cryptography.algorithms.SHA256
 import io.ktor.http.URLBuilder
 import kotlinx.coroutines.runBlocking
 import work.socialhub.kbsky.api.entity.share.Response
@@ -101,10 +102,10 @@ class _OAuthResource(
                         .keyPairGenerator(EC.Curve.P256).generateKeyBlocking()
 
                     context.publicKey = Base64.encode(
-                        keyPair.publicKey.encodeToBlocking(EC.PublicKey.Format.DER)
+                        keyPair.publicKey.encodeToByteArrayBlocking(EC.PublicKey.Format.DER)
                     )
                     context.privateKey = Base64.encode(
-                        keyPair.privateKey.encodeToBlocking(EC.PrivateKey.Format.DER)
+                        keyPair.privateKey.encodeToByteArrayBlocking(EC.PrivateKey.Format.DER)
                     )
                 }
 
@@ -124,12 +125,12 @@ class _OAuthResource(
                     sign = { jwtMessage ->
                         val privateKey = CryptographyProvider.Default.get(ECDSA)
                             .privateKeyDecoder(EC.Curve.P256)
-                            .decodeFromBlocking(
+                            .decodeFromByteArrayBlocking(
                                 EC.PrivateKey.Format.DER,
                                 Base64.decode(context.privateKey!!)
                             )
 
-                        privateKey.signatureGenerator(SHA256)
+                        privateKey.signatureGenerator(SHA256, SignatureFormat.RAW)
                             .generateSignatureBlocking(jwtMessage.encodeToByteArray())
                     }
                 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotest-assertions = { module = "io.kotest:kotest-assertions-core-jvm", version.r
 nexus-publish = "io.github.gradle-nexus.publish-plugin:io.github.gradle-nexus.publish-plugin.gradle.plugin:2.0.0"
 maven-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
-cryptography-bom = "dev.whyoleg.cryptography:cryptography-bom:0.3.1"
+cryptography-bom = "dev.whyoleg.cryptography:cryptography-bom:0.4.0"
 cryptography-core = { module = "dev.whyoleg.cryptography:cryptography-core" }
 cryptography-openssl = { module = "dev.whyoleg.cryptography:cryptography-provider-openssl3-prebuilt" }
 cryptography-jdk = { module = "dev.whyoleg.cryptography:cryptography-provider-jdk" }


### PR DESCRIPTION
On Android, cryptography 0.3.1 did not sign well, so I updated to 0.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced cryptographic operations for improved security and clarity.
  
- **Bug Fixes**
	- Updated methods for key encoding and signature generation to align with new library standards.

- **Chores**
	- Updated library and plugin versions to ensure compatibility and access to the latest features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->