### PR TITLE
Add ActorDefsLabelersPref to ActorDefsPreferencesUnion

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelerPrefItem.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelerPrefItem.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ActorDefsLabelerPrefItem(
-    var did: String
+    val did: String
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelerPrefItem.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelerPrefItem.kt
@@ -1,0 +1,8 @@
+package work.socialhub.kbsky.model.app.bsky.actor
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ActorDefsLabelerPrefItem(
+    var did: String
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelersPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelersPref.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.model.app.bsky.actor
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+class ActorDefsLabelersPref : ActorDefsPreferencesUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ActorDefs + "#labelersPref"
+    }
+
+    @SerialName("\$type")
+    override var type = TYPE
+
+    @SerialName("labelers")
+    var labelers: List<ActorDefsLabelerPrefItem>? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPreferencesUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPreferencesUnion.kt
@@ -12,6 +12,7 @@ import work.socialhub.kbsky.util.json.ActorDefsPreferencesPolymorphicSerializer
  * @see ActorDefsSavedFeedsPrefV2
  * @see ActorDefsFeedViewPref
  * @see ActorDefsThreadViewPref
+ * @see ActorDefsLabelersPref
  */
 @Serializable(with = ActorDefsPreferencesPolymorphicSerializer::class)
 abstract class ActorDefsPreferencesUnion {
@@ -25,4 +26,5 @@ abstract class ActorDefsPreferencesUnion {
     val asSavedFeedsPrefV2 get() = this as? ActorDefsSavedFeedsPrefV2
     val asFeedViewPref get() = this as? ActorDefsFeedViewPref
     val asThreadViewPref get() = this as? ActorDefsThreadViewPref
+    val asLabelersPref get() = this as? ActorDefsLabelersPref
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ActorDefsPreferencesPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ActorDefsPreferencesPolymorphicSerializer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.JsonElement
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsAdultContentPref
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsContentLabelPref
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsFeedViewPref
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsLabelersPref
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsPersonalDetailsPref
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsPreferencesUnion
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsSavedFeedsPref
@@ -30,6 +31,7 @@ object ActorDefsPreferencesPolymorphicSerializer :
             ActorDefsSavedFeedsPrefV2.TYPE -> ActorDefsSavedFeedsPrefV2.serializer()
             ActorDefsFeedViewPref.TYPE -> ActorDefsFeedViewPref.serializer()
             ActorDefsThreadViewPref.TYPE -> ActorDefsThreadViewPref.serializer()
+            ActorDefsLabelersPref.TYPE -> ActorDefsLabelersPref.serializer()
             else -> {
                 println("[Warning] Unknown Item type: $type (ActorDefsPreferencesUnion)")
                 Unknown.serializer()


### PR DESCRIPTION
Added `ActorDefsLabelersPref`.

It can be used to retrieve the labeler selected by the user on the web from the app.
(ユーザーがBluesky の Webで選択したラベラーをアプリから取得するために利用できます。)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new data class, `ActorDefsLabelerPrefItem`, for managing unique identifiers associated with actors.
	- Added a new class, `ActorDefsLabelersPref`, for handling labeler preferences linked to actor definitions.
	- Enhanced the `ActorDefsPreferencesUnion` class to support casting to `ActorDefsLabelersPref`.

- **Improvements**
	- Updated the serializer to recognize and handle the new `ActorDefsLabelersPref` type for better data management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->