### PR TITLE
Add `AuthProvider.acceptLabelers` to set `atproto-accept-labelers` header

### DIFF
--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/OAuthProvider.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/OAuthProvider.kt
@@ -113,4 +113,6 @@ class OAuthProvider(
             }
         }
     }
+
+    override var acceptLabelers: List<String> = emptyList()
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthProvider.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthProvider.kt
@@ -20,4 +20,7 @@ interface AuthProvider {
 
     val did: String
     val pdsDid: String
+
+    // TODO: This is a temporary solution to avoid circular dependencies1
+    var acceptLabelers: List<String>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/auth/BearerTokenAuthProvider.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/auth/BearerTokenAuthProvider.kt
@@ -55,4 +55,6 @@ class BearerTokenAuthProvider(
         var iat: Int = -1
         var exp: Int = -1
     }
+
+    override var acceptLabelers: List<String> = emptyList()
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
@@ -123,6 +123,8 @@ object _InternalUtility {
     suspend fun HttpRequest.getWithAuth(
         auth: AuthProvider
     ): HttpResponse {
+        addContentLabelersHeader(auth.acceptLabelers)
+
         val method = Get.value
         auth.beforeRequestHook(method, this)
         val first = this.get()
@@ -138,6 +140,8 @@ object _InternalUtility {
     suspend fun HttpRequest.postWithAuth(
         auth: AuthProvider
     ): HttpResponse {
+        addContentLabelersHeader(auth.acceptLabelers)
+
         val method = Post.value
         auth.beforeRequestHook(method, this)
         val first = this.post()
@@ -148,5 +152,13 @@ object _InternalUtility {
         val second = this.post()
         auth.afterRequestHook(method, this, second)
         return second
+    }
+
+    private fun HttpRequest.addContentLabelersHeader(acceptLabelers: List<String>) {
+
+        if (acceptLabelers.isNotEmpty()) {
+            val labelers = acceptLabelers.joinToString(", ")
+            this.header("atproto-accept-labelers", labelers)
+        }
     }
 }


### PR DESCRIPTION
fix #66 

ラベラー対応のために任意のラベラーを acceptLabelers として指定できるようにしました。

例えば 各 Request の auth パラメータに、

```
    BearerTokenAuthProvider(accessJwt).also {
        it.acceptLabelers = listOf("did:plc:ar7c4by46qjdydhdevvrndac;redact")  // Bluesky公式ラベラー
    }
```

のように設定した `AuthProvider` を引き渡すことでラベラーを指定できます。

とはいえ `AuthProvider` にラベラーを設定するのは Auth の用途とはちょっと違う気がするので、AuthProvider の名前を変えるか、別のI/Fを設定するのもいいかと思います。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `acceptLabelers` in the OAuth and Bearer Token authentication providers to enhance functionality.
	- Added new methods to improve HTTP request handling by incorporating headers based on authentication configurations.

- **Bug Fixes**
	- Enhanced header management in `getWithAuth` and `postWithAuth` methods for better interaction with authentication providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->