### PR TITLE
Jetstream which is usable for Java

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/JetStreamClient.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/JetStreamClient.kt
@@ -1,5 +1,8 @@
 package work.socialhub.kbsky.stream.entity.app.bsky
 
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import work.socialhub.kbsky.internal.share._InternalUtility
 import work.socialhub.kbsky.stream.entity.app.bsky.callback.JetStreamEventCallback
 import work.socialhub.kbsky.stream.entity.app.bsky.model.Event
@@ -44,6 +47,13 @@ class JetStreamClient(
 
     suspend fun open() {
         client.open()
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    fun openAsync() {
+        GlobalScope.launch {
+            client.open()
+        }
     }
 
     fun close() {

--- a/stream/src/jvmTest/kotlin/work/socialhub/kbsky/stream/AbstractTest.kt
+++ b/stream/src/jvmTest/kotlin/work/socialhub/kbsky/stream/AbstractTest.kt
@@ -14,44 +14,6 @@ import java.io.InputStream
 import kotlin.test.BeforeTest
 
 open class AbstractTest {
-    protected lateinit var handle: String
-    protected lateinit var password: String
-    protected lateinit var accessJwt: String
-
-    @BeforeTest
-    fun setupTest() {
-        try {
-            // Get account handle and password.
-            val json = readFile("../secrets.json")
-            val props = fromJson<Map<String, String>>(json!!)
-
-            handle = checkNotNull(props["handle"]) { "missing handle." }
-            password = checkNotNull(props["password"]) { "missing password." }
-
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-
-        // restore session.
-        readAccessJwt()
-    }
-
-    /**
-     * Read Access JWT
-     */
-    fun readAccessJwt() {
-        val jwt = readFile("../jwt.txt")
-        if (jwt != null) {
-            accessJwt = jwt
-        }
-    }
-
-    /**
-     * Save Access JWT
-     */
-    fun saveAccessJwt() {
-        saveFile(accessJwt, "../jwt.txt")
-    }
 
     @Synchronized
     fun print(record: RecordUnion) {


### PR DESCRIPTION
`suspend` function can't be used for Java( [Call a Kotlin suspend function from Java - Stack Overflow](https://stackoverflow.com/questions/71598757/) ) so add `GlobalScope.launch` version.
Following article says `GlobalScope.launch` is "delicate API" but "can be legitimately and safely used, such as top-level background processes that must stay active for the whole duration of an application’s lifetime".
[Kotlin Coroutines 1.5: GlobalScope Marked as Delicate, Refined Channels API, and More | The Kotlin Blog](https://blog.jetbrains.com/kotlin/2021/05/kotlin-coroutines-1-5-0-released/#legitimate-use-cases)
Jetstream will be used as above, I think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new asynchronous method `openAsync` for the WebSocket client, enhancing non-blocking connectivity.

- **Bug Fixes**
  - Removed outdated user credential handling and session management methods from the testing framework, streamlining the testing process. 

These updates aim to improve application responsiveness and simplify the testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->