### PR TITLE
Issue 113 - Added support to use OAuth refresh tokens and confidential client types.

### DIFF
--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthConfig.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthConfig.kt
@@ -7,7 +7,7 @@ class AuthConfig {
     var pdsServer = BSKY_SOCIAL.uri
     var authorizationServer = BSKY_SOCIAL.uri
 
-    var tokenEndpoint = "${BSKY_SOCIAL.uri}oauth/token"
-    var authorizationEndpoint = "${BSKY_SOCIAL.uri}oauth/authorize"
-    var pushedAuthorizationRequestEndpoint = "${BSKY_SOCIAL.uri}oauth/par"
+    var tokenEndpoint = "${BSKY_SOCIAL.uri}/oauth/token"
+    var authorizationEndpoint = "${BSKY_SOCIAL.uri}/oauth/authorize"
+    var pushedAuthorizationRequestEndpoint = "${BSKY_SOCIAL.uri}/oauth/par"
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/OAuthSession.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/OAuthSession.kt
@@ -11,5 +11,5 @@ open class OAuthSession {
     var publicKey: String? = null
     var privateKey: String? = null
 
-    var dPoPNonce: String? = null
+    var dPoPNonce: String = ""
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthPushedAuthorizationRequest.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthPushedAuthorizationRequest.kt
@@ -20,11 +20,11 @@ class OAuthPushedAuthorizationRequest : MapRequest {
     var codeChallengeMethod = "S256"
 
     /**
-     * Must be a signed JWT for confidential clients
+     * Required for confidential OAuth clients.
      */
     var keyId: String? = null
-    var clientAssertion: String? = null
     var clientAssertionType: String? = null
+    var clientAssertion: String? = null
 
     var state: String? = null
     // var nonce: String? = null

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthPushedAuthorizationRequest.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthPushedAuthorizationRequest.kt
@@ -19,6 +19,13 @@ class OAuthPushedAuthorizationRequest : MapRequest {
     var codeChallenge: String? = null
     var codeChallengeMethod = "S256"
 
+    /**
+     * Must be a signed JWT for confidential clients
+     */
+    var keyId: String? = null
+    var clientAssertion: String? = null
+    var clientAssertionType: String? = null
+
     var state: String? = null
     // var nonce: String? = null
 
@@ -26,14 +33,20 @@ class OAuthPushedAuthorizationRequest : MapRequest {
 
     override fun toMap(): Map<String, Any> =
         mutableMapOf<String, Any>().also {
+            it.addParam("client_assertion_type", clientAssertionType)
+            it.addParam("client_assertion", clientAssertion)
             it.addParam("client_id", clientId)
             it.addParam("redirect_uri", redirectUri)
             it.addParam("response_type", responseType)
             it.addParam("scope", scope.joinToString(" "))
-
             it.addParam("code_challenge", codeChallenge)
             it.addParam("code_challenge_method", codeChallengeMethod)
-            it.addParam("login_hint", loginHint)
+
+            if (loginHint?.isNotBlank() == true) {
+                it.addParam("login_hint", loginHint)
+            }
             it.addParam("state", state)
+
+
         }
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
@@ -12,9 +12,11 @@ class OAuthTokenRequest : MapRequest {
     var refreshToken = ""
 
     /**
-     * Must be a signed JWT for confidential clients
+     * Required for confidential OAuth clients.
      */
-    var client_assertion = ""
+    var keyId: String? = null
+    var clientAssertionType: String? = null
+    var clientAssertion: String? = null
 
     var code = ""
     var codeVerifier = ""
@@ -44,8 +46,9 @@ class OAuthTokenRequest : MapRequest {
             if (refreshToken.isNotBlank()) {
                 it.addParam("refresh_token", refreshToken)
             }
-            if (client_assertion.isNotBlank()) {
-                it.addParam("client_assertion", client_assertion)
+            if (clientAssertion?.isNotBlank() == true) {
+                it.addParam("client_assertion", clientAssertion)
+                it.addParam("client_assertion_type", clientAssertionType)
             }
         }
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
@@ -4,11 +4,12 @@ import work.socialhub.kbsky.api.entity.share.MapRequest
 
 class OAuthTokenRequest : MapRequest {
 
-    var responseType = "code"
     var grantType = "authorization_code"
+    var responseType = ""
 
     var clientId = ""
     var redirectUri = ""
+    var refreshToken = ""
 
     var code = ""
     var codeVerifier = ""
@@ -17,13 +18,26 @@ class OAuthTokenRequest : MapRequest {
 
     override fun toMap(): Map<String, Any> =
         mutableMapOf<String, Any>().also {
-            it.addParam("response_type", responseType)
+            //Compulsory field
             it.addParam("grant_type", grantType)
 
-            it.addParam("client_id", clientId)
-            it.addParam("redirect_uri", redirectUri)
-
-            it.addParam("code", code)
-            it.addParam("code_verifier", codeVerifier)
+            if (responseType.isNotBlank()) {
+                it.addParam("response_type", responseType)
+            }
+            if (clientId.isNotBlank()) {
+                it.addParam("client_id", clientId)
+            }
+            if (redirectUri.isNotBlank()) {
+                it.addParam("redirect_uri", redirectUri)
+            }
+            if (code.isNotBlank()) {
+                it.addParam("code", code)
+            }
+            if (codeVerifier.isNotBlank()) {
+                it.addParam("code_verifier", codeVerifier)
+            }
+            if (refreshToken.isNotBlank()) {
+                it.addParam("refresh_token", refreshToken)
+            }
         }
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
@@ -45,7 +45,7 @@ class OAuthTokenRequest : MapRequest {
                 it.addParam("refresh_token", refreshToken)
             }
             if (client_assertion.isNotBlank()) {
-                it.addParam("client_assertion", refreshToken)
+                it.addParam("client_assertion", client_assertion)
             }
         }
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/api/entity/oauth/OAuthTokenRequest.kt
@@ -11,6 +11,11 @@ class OAuthTokenRequest : MapRequest {
     var redirectUri = ""
     var refreshToken = ""
 
+    /**
+     * Must be a signed JWT for confidential clients
+     */
+    var client_assertion = ""
+
     var code = ""
     var codeVerifier = ""
 
@@ -38,6 +43,9 @@ class OAuthTokenRequest : MapRequest {
             }
             if (refreshToken.isNotBlank()) {
                 it.addParam("refresh_token", refreshToken)
+            }
+            if (client_assertion.isNotBlank()) {
+                it.addParam("client_assertion", refreshToken)
             }
         }
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/helper/OAuthHelper.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/helper/OAuthHelper.kt
@@ -80,12 +80,13 @@ object OAuthHelper {
             put("nonce", dPoPNonce)
         }
 
-        // Signature
-        val headerBase64 = Base64.encode(headerJson.toString().toByteArray())
-        val payloadBase64 = Base64.encode(payloadJson.toString().toByteArray())
+        //We need to remove any padding characters (=) to ensure we are compliant
+        //Ideally we'd be using a dedicated JWT library to take care of this for us.
+        val headerBase64 = Base64.UrlSafe.encode(headerJson.toString().toByteArray()).replace("=", "");
+        val payloadBase64 = Base64.UrlSafe.encode(payloadJson.toString().toByteArray()).replace("=", "");
         val jwtMessage = "$headerBase64.$payloadBase64"
 
-        val jwtSignature = Base64.encode(sign(jwtMessage))
+        val jwtSignature = Base64.UrlSafe.encode(sign(jwtMessage)).replace("=", "");
         return "$headerBase64.$payloadBase64.$jwtSignature"
     }
 
@@ -115,15 +116,16 @@ object OAuthHelper {
             // random token string (unique per request)
             put("jti", generateRandomValue())
             put("iat", epoch)
-            put("exp", epoch + 60)
+            put("exp", epoch + 300)
         }
 
-        // Signature
-        val headerBase64 = Base64.encode(headerJson.toString().toByteArray())
-        val payloadBase64 = Base64.encode(payloadJson.toString().toByteArray())
+        //We need to remove any padding characters (=) to ensure we are compliant
+        //Ideally we'd be using a dedicated JWT library to take care of this for us.
+        val headerBase64 = Base64.UrlSafe.encode(headerJson.toString().toByteArray()).replace("=", "");
+        val payloadBase64 = Base64.UrlSafe.encode(payloadJson.toString().toByteArray()).replace("=", "");
         val jwtMessage = "$headerBase64.$payloadBase64"
 
-        val jwtSignature = Base64.encode(sign(jwtMessage))
+        val jwtSignature = Base64.UrlSafe.encode(sign(jwtMessage)).replace("=", "");
         return "$headerBase64.$payloadBase64.$jwtSignature"
     }
 

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/helper/OAuthHelper.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/helper/OAuthHelper.kt
@@ -76,7 +76,8 @@ object OAuthHelper {
             put("exp", epoch + 60)
             // random token string (unique per request)
             put("jti", generateRandomValue())
-            put("iat", epoch)
+            //In the past to help with minor clock skew
+            put("iat", epoch - 10)
             put("nonce", dPoPNonce)
         }
 
@@ -115,7 +116,8 @@ object OAuthHelper {
 
             // random token string (unique per request)
             put("jti", generateRandomValue())
-            put("iat", epoch)
+            //In the past to help with minor clock skew
+            put("iat", epoch - 10)
             put("exp", epoch + 300)
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = "work.socialhub.kbsky"
-    version = "0.3.0-SNAPSHOT"
+    version = "0.3.0-EBX-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = "work.socialhub.kbsky"
-    version = "0.3.0-EBX-SNAPSHOT"
+    version = "0.3.0-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/domain/Service.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/domain/Service.kt
@@ -4,9 +4,9 @@ enum class Service(
     val uri: String
 ) {
     //
-    BSKY_SOCIAL("https://bsky.social/"),
-    BSKY_NETWORK("https://bsky.network/"),
-    BSKY_APP_PUBLIC("https://public.api.bsky.app/"),
+    BSKY_SOCIAL("https://bsky.social"),
+    BSKY_NETWORK("https://bsky.network"),
+    BSKY_APP_PUBLIC("https://public.api.bsky.app"),
 
-    OYSTER_US_EAST("https://oyster.us-east.host.bsky.network/"),
+    OYSTER_US_EAST("https://oyster.us-east.host.bsky.network"),
 }


### PR DESCRIPTION
Please find attached my changes to support refreshing OAuth tokens:

    Auth oAuth = AuthFactory.INSTANCE.instance(Service.BSKY_SOCIAL.getUri());
    
    //Define oAuthContext same as before
    OAuthTokenRequest oAuthTokenRequest = new OAuthTokenRequest();
    oAuthTokenRequest.setGrantType("refresh_token");
    oAuthTokenRequest.setRefreshToken(refreshToken);

    Response<OAuthTokenResponse> oAuthTokenResponse = oAuth.oauth().tokenRequest(oAuthContext, oAuthTokenRequest);
    
While adding this support I made a few other changes:

1. Defaulted dPoPNonce to an empty string to avoid having to initialise this in the client.
2. Added a postWithRetry method for token operations so that they get seamlessly retried on a nonce error.
3. Implementation to support confidential web clients which require a client_assertion. This lead to also requiring 4 and 5.
4. The way JWTs are being created is not URL safe in this library which causes problems for the client_assertion which is more strict. I have hacked a fix for this here but I recommend using a dedicated JWT library to avoid similar problems.
5. The base URLs specified in Service.kt included forward slashes which fails parsing in client_assertions. I have swapped the defaults around NOT to include forward slashes, which then get readded in AuthConfig.kt. I would recommend initialising these URLs via the values returned by WellKnownOAuthAuthorizationServerResponse for better future proofing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to generate JWT client assertions in the OAuth flow.
	- Added new properties for handling client assertions in authorization requests.
	- Enhanced OAuth token requests with improved conditional parameter inclusion.
	- Implemented a retry mechanism for HTTP requests in OAuth processes.

- **Bug Fixes**
	- Corrected formatting of endpoint URIs in the authentication configuration.
	- Removed trailing slashes from service URIs for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->