### PR TITLE
Adds support for StarterPacks

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -1,7 +1,5 @@
 package work.socialhub.kbsky
 
-import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPack
-
 /**
  * Bluesky/ATProtocol
  * https://atproto.com/docs

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kbsky
 
+import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPack
+
 /**
  * Bluesky/ATProtocol
  * https://atproto.com/docs
@@ -66,6 +68,7 @@ object BlueskyTypes {
     const val GraphListItem = "app.bsky.graph.listitem"
     const val GraphGetStarterPack = "app.bsky.graph.getStarterPack"
     const val GraphGetStarterPacks = "app.bsky.graph.getStarterPacks"
+    const val GraphStarterPack = "app.bsky.graph.starterpack"
 
 
     // Labeler

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -64,6 +64,9 @@ object BlueskyTypes {
     const val GraphGetLists = "app.bsky.graph.getLists"
     const val GraphList = "app.bsky.graph.list"
     const val GraphListItem = "app.bsky.graph.listitem"
+    const val GraphGetStarterPack = "app.bsky.graph.getStarterPack"
+    const val GraphGetStarterPacks = "app.bsky.graph.getStarterPacks"
+
 
     // Labeler
     const val LabelerDefs = "app.bsky.labeler.defs"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
@@ -27,6 +27,10 @@ import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetMutesRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetMutesResponse
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPackRequest
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPackResponse
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPacksRequest
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPacksResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphMuteActorRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphRemoveUserFromListRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphUnmuteActorRequest
@@ -172,5 +176,21 @@ interface GraphResource {
     fun removeUserFromList(
         request: GraphRemoveUserFromListRequest
     ): Response<Unit>
+
+
+    /**
+     * Gets a view of a starter pack.
+     */
+    fun getStarterPack(
+        request: GraphGetStarterPackRequest
+    ): Response<GraphGetStarterPackResponse>
+
+    /**
+     * Gets a view of a starter pack.
+     */
+    fun getStarterPacks(
+        request: GraphGetStarterPacksRequest
+    ): Response<GraphGetStarterPacksResponse>
+
 
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
@@ -177,7 +177,6 @@ interface GraphResource {
         request: GraphRemoveUserFromListRequest
     ): Response<Unit>
 
-
     /**
      * Gets a view of a starter pack.
      */
@@ -191,6 +190,4 @@ interface GraphResource {
     fun getStarterPacks(
         request: GraphGetStarterPacksRequest
     ): Response<GraphGetStarterPacksResponse>
-
-
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackRequest.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.api.entity.app.bsky.graph
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+
+class GraphGetStarterPackRequest (
+    auth: AuthProvider
+) : AuthRequest(auth), MapRequest {
+
+    var starterPack: String? = null
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("starterPack", starterPack)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackRequest.kt
@@ -4,7 +4,7 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetStarterPackRequest (
+class GraphGetStarterPackRequest(
     auth: AuthProvider
 ) : AuthRequest(auth), MapRequest {
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackResponse.kt
@@ -1,9 +1,9 @@
 package work.socialhub.kbsky.api.entity.app.bsky.graph
 
 import kotlinx.serialization.Serializable
-import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPackView
+import work.socialhub.kbsky.model.app.bsky.graph.GraphDefsStarterPackView
 
 @Serializable
 data class GraphGetStarterPackResponse(
-    var starterPack: GraphStarterPackView
+    var starterPack: GraphDefsStarterPackView
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackResponse.kt
@@ -5,5 +5,5 @@ import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPackView
 
 @Serializable
 data class GraphGetStarterPackResponse(
-    val starterPack: GraphStarterPackView
+    var starterPack: GraphStarterPackView
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackResponse.kt
@@ -1,0 +1,9 @@
+package work.socialhub.kbsky.api.entity.app.bsky.graph
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPackView
+
+@Serializable
+data class GraphGetStarterPackResponse(
+    val starterPack: GraphStarterPackView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksRequest.kt
@@ -4,7 +4,7 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetStarterPacksRequest (
+class GraphGetStarterPacksRequest(
     auth: AuthProvider
 ) : AuthRequest(auth), MapRequest {
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksRequest.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.api.entity.app.bsky.graph
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+
+class GraphGetStarterPacksRequest (
+    auth: AuthProvider
+) : AuthRequest(auth), MapRequest {
+
+    var uris: List<String>? = null
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("uris", uris)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksResponse.kt
@@ -1,0 +1,11 @@
+package work.socialhub.kbsky.api.entity.app.bsky.graph
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
+import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPackView
+
+@Serializable
+data class GraphGetStarterPacksResponse (
+    var starterPacks: List<FeedDefsPostView>
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksResponse.kt
@@ -1,11 +1,9 @@
 package work.socialhub.kbsky.api.entity.app.bsky.graph
 
 import kotlinx.serialization.Serializable
-import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
-import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
-import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPackView
+import work.socialhub.kbsky.model.app.bsky.graph.GraphDefsStarterPackViewBasic
 
 @Serializable
 data class GraphGetStarterPacksResponse (
-    var starterPacks: List<FeedDefsPostView>
+    var starterPacks: List<GraphDefsStarterPackViewBasic>
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.graph.GraphDefsStarterPackViewBasic
 
 @Serializable
-data class GraphGetStarterPacksResponse (
+data class GraphGetStarterPacksResponse(
     var starterPacks: List<GraphDefsStarterPackViewBasic>
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_GraphResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_GraphResource.kt
@@ -13,6 +13,8 @@ import work.socialhub.kbsky.BlueskyTypes.GraphGetKnownFollowers
 import work.socialhub.kbsky.BlueskyTypes.GraphGetList
 import work.socialhub.kbsky.BlueskyTypes.GraphGetLists
 import work.socialhub.kbsky.BlueskyTypes.GraphGetMutes
+import work.socialhub.kbsky.BlueskyTypes.GraphGetStarterPack
+import work.socialhub.kbsky.BlueskyTypes.GraphGetStarterPacks
 import work.socialhub.kbsky.BlueskyTypes.GraphList
 import work.socialhub.kbsky.BlueskyTypes.GraphListItem
 import work.socialhub.kbsky.BlueskyTypes.GraphMuteActor
@@ -45,6 +47,10 @@ import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetListsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetMutesRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetMutesResponse
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPackRequest
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPackResponse
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPacksRequest
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPacksResponse
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphMuteActorRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphRemoveUserFromListRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphUnmuteActorRequest
@@ -412,6 +418,34 @@ class _GraphResource(
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
                     .postWithAuth(request.auth)
+            }
+        }
+    }
+
+    override fun getStarterPack(request: GraphGetStarterPackRequest): Response<GraphGetStarterPackResponse> {
+        return proceed {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, GraphGetStarterPack))
+                    .accept(MediaType.JSON)
+                    .queries(request.toMap())
+                    .getWithAuth(request.auth)
+            }
+        }
+    }
+
+    override fun getStarterPacks(request: GraphGetStarterPacksRequest): Response<GraphGetStarterPacksResponse> {
+        return proceed {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, GraphGetStarterPacks))
+                    .accept(MediaType.JSON)
+                    .also {
+                        request.uris?.forEach { uri ->
+                            it.query("uris", uri)
+                        }
+                    }
+                    .getWithAuth(request.auth)
             }
         }
     }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphDefsStarterPackView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphDefsStarterPackView.kt
@@ -7,16 +7,16 @@ import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-data class GraphStarterPackView(
+data class GraphDefsStarterPackView(
     val uri: String,
     val cid: String,
     val record: RecordUnion,
     val creator: ActorDefsProfileViewBasic,
-    val list: GraphDefsListViewBasic,
-    val listItemsSample: List<GraphDefsListItemView>,
-    val feeds: List<FeedDefsGeneratorView>,
-    val joinedWeekCount: Int,
-    val joinedAllTimeCount: Int,
-    val labels: List<LabelDefsLabel>,
+    val list: GraphDefsListViewBasic? = null,
+    val listItemsSample: List<GraphDefsListItemView>? = null,
+    val feeds: List<FeedDefsGeneratorView>? = null,
+    val joinedWeekCount: Int? = null,
+    val joinedAllTimeCount: Int? = null,
+    val labels: List<LabelDefsLabel>? = null,
     val indexedAt: String
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphDefsStarterPackViewBasic.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphDefsStarterPackViewBasic.kt
@@ -11,8 +11,9 @@ data class GraphDefsStarterPackViewBasic(
     val cid: String,
     val record: RecordUnion,
     val creator: ActorDefsProfileViewBasic,
-    val joinedWeekCount: Int,
-    val joinedAllTimeCount: Int,
-    val labels: List<LabelDefsLabel>,
+    val listItemCount: Int? = null,
+    val joinedWeekCount: Int? = null,
+    val joinedAllTimeCount: Int? = null,
+    val labels: List<LabelDefsLabel>? = null,
     val indexedAt: String
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphDefsStarterPackViewBasic.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphDefsStarterPackViewBasic.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.model.app.bsky.graph
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewBasic
+import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
+import work.socialhub.kbsky.model.share.RecordUnion
+
+@Serializable
+data class GraphDefsStarterPackViewBasic(
+    val uri: String,
+    val cid: String,
+    val record: RecordUnion,
+    val creator: ActorDefsProfileViewBasic,
+    val joinedWeekCount: Int,
+    val joinedAllTimeCount: Int,
+    val labels: List<LabelDefsLabel>,
+    val indexedAt: String
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphStarterPack.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphStarterPack.kt
@@ -1,0 +1,30 @@
+package work.socialhub.kbsky.model.app.bsky.graph
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.model.app.bsky.richtext.RichtextFacet
+import work.socialhub.kbsky.model.share.RecordUnion
+
+@Serializable
+class GraphStarterPack : RecordUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.GraphStarterPack
+    }
+
+    @SerialName("\$type")
+    override var type = TYPE
+
+    /** Display name for starter pack; can not be empty. */
+    var name: String? = null
+
+    var description: String? = null
+    var descriptionFacets: List<RichtextFacet>? = null
+
+    /** Reference (AT-URI) to the list record. */
+    var list: String? = null
+
+    var feeds: List<GraphStarterPackFeedItem>? = null
+    var createdAt: String? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphStarterPackFeedItem.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphStarterPackFeedItem.kt
@@ -1,0 +1,9 @@
+package work.socialhub.kbsky.model.app.bsky.graph
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GraphStarterPackFeedItem(
+    /** at-uri */
+    var uri: String
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphStarterPackView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/graph/GraphStarterPackView.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.model.app.bsky.graph
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewBasic
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsGeneratorView
+import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
+import work.socialhub.kbsky.model.share.RecordUnion
+
+@Serializable
+data class GraphStarterPackView(
+    val uri: String,
+    val cid: String,
+    val record: RecordUnion,
+    val creator: ActorDefsProfileViewBasic,
+    val list: GraphDefsListViewBasic,
+    val listItemsSample: List<GraphDefsListItemView>,
+    val feeds: List<FeedDefsGeneratorView>,
+    val joinedWeekCount: Int,
+    val joinedAllTimeCount: Int,
+    val labels: List<LabelDefsLabel>,
+    val indexedAt: String
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/share/RecordUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/share/RecordUnion.kt
@@ -10,6 +10,7 @@ import work.socialhub.kbsky.model.app.bsky.graph.GraphBlock
 import work.socialhub.kbsky.model.app.bsky.graph.GraphFollow
 import work.socialhub.kbsky.model.app.bsky.graph.GraphList
 import work.socialhub.kbsky.model.app.bsky.graph.GraphListItem
+import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPack
 import work.socialhub.kbsky.util.json.RecordPolymorphicSerializer
 
 /**
@@ -35,4 +36,5 @@ abstract class RecordUnion {
     val asFeedRepost get() = this as? FeedRepost
     val asGraphListItem get() = this as? GraphListItem
     val asGraphList get() = this as? GraphList
+    val asGraphStarterPack get() = this as? GraphStarterPack
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/RecordPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/RecordPolymorphicSerializer.kt
@@ -14,6 +14,7 @@ import work.socialhub.kbsky.model.app.bsky.graph.GraphBlock
 import work.socialhub.kbsky.model.app.bsky.graph.GraphFollow
 import work.socialhub.kbsky.model.app.bsky.graph.GraphList
 import work.socialhub.kbsky.model.app.bsky.graph.GraphListItem
+import work.socialhub.kbsky.model.app.bsky.graph.GraphStarterPack
 import work.socialhub.kbsky.model.share.RecordUnion
 import work.socialhub.kbsky.util.json.JsonElementUtil.type
 
@@ -37,6 +38,7 @@ object RecordPolymorphicSerializer :
             GraphList.TYPE -> GraphList.serializer()
             FeedThreadgate.TYPE -> FeedThreadgate.serializer()
             FeedPostgate.TYPE -> FeedPostgate.serializer()
+            GraphStarterPack.TYPE -> GraphStarterPack.serializer()
 
             else -> {
                 println("[Warning] Unknown Item type: $type (RecordUnion)")

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPackTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPackTest.kt
@@ -19,6 +19,6 @@ class GetGraphStarterPackTest : AbstractTest() {
                 }
             )
 
-        print(response.data.starterPack)
+        println("Name: ${response.data.starterPack.record.asGraphStarterPack?.name}")
     }
 }

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPackTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPackTest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.app.bsky.graph
+
+import work.socialhub.kbsky.AbstractTest
+import work.socialhub.kbsky.BlueskyFactory
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPackRequest
+import work.socialhub.kbsky.domain.Service.BSKY_SOCIAL
+import kotlin.test.Test
+
+class GetGraphStarterPackTest : AbstractTest() {
+
+    @Test
+    fun testGetStarterPack() {
+        val response = BlueskyFactory
+            .instance(BSKY_SOCIAL.uri)
+            .graph()
+            .getStarterPack(
+                GraphGetStarterPackRequest(auth()).also {
+                    it.starterPack = "at://did:plc:xpu5e52rhk6a3efljymgnmz4/app.bsky.graph.list/3lbpq5dooda2k"
+                }
+            )
+
+        print(response.data.starterPack)
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPacksTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPacksTest.kt
@@ -1,0 +1,29 @@
+package work.socialhub.kbsky.app.bsky.graph
+
+import work.socialhub.kbsky.AbstractTest
+import work.socialhub.kbsky.BlueskyFactory
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphGetStarterPacksRequest
+import work.socialhub.kbsky.domain.Service.BSKY_SOCIAL
+import kotlin.test.Test
+
+class GetGraphStarterPacksTest : AbstractTest() {
+
+    val starterPacks = listOf(
+        "at://did:plc:xpu5e52rhk6a3efljymgnmz4/app.bsky.graph.list/3lbpq5dooda2k"
+    )
+
+    @Test
+    fun testGetStarterPacks() {
+        val response = BlueskyFactory
+            .instance(BSKY_SOCIAL.uri)
+            .graph()
+            .getStarterPacks(
+                GraphGetStarterPacksRequest(auth()).also {
+                    it.uris = starterPacks
+                }
+            )
+
+        response.data.starterPacks
+            .forEach { print(it) }
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPacksTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/GetGraphStarterPacksTest.kt
@@ -23,7 +23,8 @@ class GetGraphStarterPacksTest : AbstractTest() {
                 }
             )
 
-        response.data.starterPacks
-            .forEach { print(it) }
+        response.data.starterPacks.forEach {
+            println("Name: ${it.record.asGraphStarterPack?.name}")
+        }
     }
 }


### PR DESCRIPTION
Adds support for retrieval of StarterPacks

  - app.bsky.graph.getStarterPack
  - app.bsky.graph.getStarterPacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for retrieving starter packs via new Graph API methods.
	- Introduced ability to fetch single and multiple starter pack views.
	- Implemented new data models for starter packs, including detailed metadata.

- **Tests**
	- Added test cases for retrieving starter packs and starter pack details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->