### PR TITLE
Add support for `posts_with_video` in FeedGetAuthorFeedRequest

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
@@ -17,6 +17,7 @@ class FeedGetAuthorFeedRequest(
         PostsWithReplies("posts_with_replies"),
         PostsNoReplies("posts_no_replies"),
         PostsWithMedia("posts_with_media"),
+        PostsWithVideo("posts_with_video"),
         PostsAndAuthorThreads("posts_and_author_threads")
     }
 


### PR DESCRIPTION
Adds the `PostsWithVideo` option to the `FeedType` enum in `FeedGetAuthorFeedRequest`, allowing filtering of posts that contain videos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a filter option that allows you to view posts containing video content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->