### PR TITLE
Refactor exception handling and error response

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolException.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocolException.kt
@@ -2,17 +2,16 @@ package work.socialhub.kbsky
 
 import work.socialhub.kbsky.api.entity.share.ErrorResponse
 
-open class ATProtocolException(
-    message: String?,
-    exception: Exception?,
+data class ATProtocolException(
+    override val message: String?,
+    val exception: Exception?,
     val status: Int?,
     val body: String?,
+    var response: ErrorResponse? = null,
 ) : RuntimeException(
     message,
     exception,
 ) {
-    var response: ErrorResponse? = null
-
     constructor(message: String?) : this(message, null, null, null)
     constructor(exception: Exception?) : this(null, exception, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyException.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyException.kt
@@ -1,8 +1,8 @@
 package work.socialhub.kbsky
 
-class BlueskyException(
-    message: String?,
-    exception: Exception?,
+data class BlueskyException(
+    override val message: String?,
+    val exception: Exception?,
 ) : RuntimeException(
     message,
     exception,

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/ErrorResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/ErrorResponse.kt
@@ -4,13 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ErrorResponse {
-    var message: String = ""
-    lateinit var error: String
-
+data class ErrorResponse(
+    var message: String = "",
+    var error: String,
     // for OAuth
     @SerialName("error_description")
-    var errorDescription: String = ""
+    var errorDescription: String = "",
+) {
 
     fun messageForDisplay(): String {
         return if (errorDescription.isNotEmpty()) {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
@@ -3,7 +3,6 @@ package work.socialhub.kbsky.internal.share
 import io.ktor.http.HttpMethod.Companion.Get
 import io.ktor.http.HttpMethod.Companion.Post
 import kotlinx.datetime.TimeZone
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import work.socialhub.kbsky.ATProtocolConfig
@@ -114,7 +113,8 @@ object _InternalUtility {
                 exception = exception,
                 status = status,
                 body = body,
-            ).also { it.response = response }
+                response = response,
+            )
         }
 
         return ATProtocolException(exception)


### PR DESCRIPTION
- Convert `BlueskyException` and `ATProtocolException` to data classes.
- Convert `ErrorResponse` to data class.
- Add a `response` parameter to the `ATProtocolException` constructor.

----

- 一応 data class 化の一環ですが、`ATProtocolException` をエラーログにダンプするときに便利なので優先的に実施しました。
- `BlueskyException` は現状未使用っぽいので削除するのも検討していいかもしれませんね。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated core error handling components by streamlining exception and error response structures. These changes provide enhanced error context and more consistent reporting behavior for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->