### PR TITLE
Add aspect ratio to embed images view image

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedDefsAspectRatio.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedDefsAspectRatio.kt
@@ -3,8 +3,7 @@ package work.socialhub.kbsky.model.app.bsky.embed
 import kotlinx.serialization.Serializable
 
 @Serializable
-class EmbedDefsAspectRatio {
-
-    var width: Int = 1
-    var height: Int = 1
-}
+data class EmbedDefsAspectRatio(
+    var width: Int = 1,
+    var height: Int = 1,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesViewImage.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesViewImage.kt
@@ -3,8 +3,8 @@ package work.socialhub.kbsky.model.app.bsky.embed
 import kotlinx.serialization.Serializable
 
 @Serializable
-class EmbedImagesViewImage {
-    var thumb: String? = null
-    var fullsize: String? = null
-    var alt: String? = null
-}
+data class EmbedImagesViewImage(
+    val thumb: String? = null,
+    val fullsize: String? = null,
+    val alt: String? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesViewImage.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesViewImage.kt
@@ -7,4 +7,5 @@ data class EmbedImagesViewImage(
     val thumb: String? = null,
     val fullsize: String? = null,
     val alt: String? = null,
+    val aspectRatio: EmbedDefsAspectRatio? = null,
 )

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/feed/PostTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/feed/PostTest.kt
@@ -66,9 +66,9 @@ class PostTest : AbstractTest() {
             image.image = response1.data.blob
             image.alt = "image test"
 
-            val aspectRatio = EmbedDefsAspectRatio()
-            aspectRatio.width = 200
-            aspectRatio.height = 100
+            val aspectRatio = EmbedDefsAspectRatio(
+                200, 100
+            )
             image.aspectRatio = aspectRatio
 
             images.add(image)


### PR DESCRIPTION
画像表示時に画像サイズ aspectRatio を参照できなかったので追加しました。

#145 と修正が被っているので恐縮ですがよろしくお願いします！

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal handling of image display dimensions for more consistent media presentation.
  
- **New Features**
  - Integrated an enhanced mechanism for managing image aspect ratios, ensuring improved visual layout in feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->