### PR TITLE
Add timeout option for OAuth methods

### DIFF
--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthConfig.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthConfig.kt
@@ -1,8 +1,9 @@
 package work.socialhub.kbsky.auth
 
+import work.socialhub.kbsky.NetworkConfig
 import work.socialhub.kbsky.domain.Service.BSKY_SOCIAL
 
-class AuthConfig {
+class AuthConfig : NetworkConfig() {
 
     var pdsServer = BSKY_SOCIAL.uri
     var authorizationServer = BSKY_SOCIAL.uri

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthFactory.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthFactory.kt
@@ -4,8 +4,12 @@ import work.socialhub.kbsky.auth.internal._Auth
 
 object AuthFactory {
 
+    fun instance(config: AuthConfig): Auth {
+        return _Auth(config)
+    }
+
     fun instance(pdsUri: String): Auth {
-        return _Auth(AuthConfig().also {
+        return instance(AuthConfig().also {
             it.pdsServer = pdsUri
         })
     }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
@@ -216,7 +216,7 @@ class _OAuthResource(
     ): HttpResponse {
 
         setDPoPHeader(context)
-        val first = this.post();
+        val first = this.post()
         if (!isRetryRequired(context, first)) {
             return first
         }
@@ -230,8 +230,8 @@ class _OAuthResource(
     private fun HttpRequest.setDPoPHeader(
         context: OAuthContext
     ) {
-        val dPoPHeader = getDPoPHeader(context, this.url!!);
-        this.header("DPoP", dPoPHeader);
+        val dPoPHeader = getDPoPHeader(context, this.url!!)
+        this.header("DPoP", dPoPHeader)
     }
 
     private fun isRetryRequired(

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
@@ -23,6 +23,7 @@ import work.socialhub.kbsky.auth.helper.OAuthHelper.extractDPoPNonce
 import work.socialhub.kbsky.auth.helper.OAuthHelper.makeClientAssertion
 import work.socialhub.kbsky.auth.helper.RandomHelper
 import work.socialhub.kbsky.internal.share._InternalUtility.proceed
+import work.socialhub.kbsky.internal.share._InternalUtility.setTimeouts
 import work.socialhub.kbsky.util.MediaType
 import work.socialhub.khttpclient.HttpRequest
 import work.socialhub.khttpclient.HttpResponse
@@ -145,6 +146,7 @@ class _OAuthResource(
                     .accept(MediaType.JSON)
                     .params(request.toMap())
                     .forceApplicationFormUrlEncoded(true)
+                    .setTimeouts(config)
                     .postWithRetry(context)
             }
         }

--- a/auth/src/jvmTest/kotlin/work/socialhub/kbsky/auth/OAuthTest.kt
+++ b/auth/src/jvmTest/kotlin/work/socialhub/kbsky/auth/OAuthTest.kt
@@ -77,7 +77,13 @@ class OAuthTest : AbstractTest() {
     @Test
     fun refreshToken() {
         val response = AuthFactory
-            .instance(BSKY_SOCIAL.uri)
+            .instance(AuthConfig().also {
+                it.pdsServer = BSKY_SOCIAL.uri
+                // set timeout
+                it.connectTimeoutMillis = 30_000
+                it.socketTimeoutMillis = 30_000
+                it.requestTimeoutMillis = 60_000
+            })
             .oauth()
             .refreshTokenRequest(
                 oAuthContext,

--- a/auth/src/jvmTest/kotlin/work/socialhub/kbsky/auth/OAuthTest.kt
+++ b/auth/src/jvmTest/kotlin/work/socialhub/kbsky/auth/OAuthTest.kt
@@ -22,7 +22,8 @@ class OAuthTest : AbstractTest() {
         val response = AuthFactory
             .instance(BSKY_SOCIAL.uri)
             .oauth()
-            .pushedAuthorizationRequest(context,
+            .pushedAuthorizationRequest(
+                context,
                 OAuthPushedAuthorizationRequest().also {
                     it.loginHint = "uakihir0.com"
                 }
@@ -32,7 +33,8 @@ class OAuthTest : AbstractTest() {
 
         val authorizeUrl = AuthFactory
             .instance(BSKY_SOCIAL.uri)
-            .oauth().buildAuthorizationUrl(context,
+            .oauth().buildAuthorizationUrl(
+                context,
                 BuildAuthorizationUrlRequest().also {
                     it.requestUri = response.data.requestUri
                 })
@@ -55,7 +57,8 @@ class OAuthTest : AbstractTest() {
         val response = AuthFactory
             .instance(BSKY_SOCIAL.uri)
             .oauth()
-            .authorizationCodeTokenRequest(oAuthContext,
+            .authorizationCodeTokenRequest(
+                oAuthContext,
                 OAuthAuthorizationCodeTokenRequest().also {
                     it.code = code!!
                 }
@@ -76,7 +79,8 @@ class OAuthTest : AbstractTest() {
         val response = AuthFactory
             .instance(BSKY_SOCIAL.uri)
             .oauth()
-            .refreshTokenRequest(oAuthContext,
+            .refreshTokenRequest(
+                oAuthContext,
                 OAuthRefreshTokenRequest(auth())
             )
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/NetworkConfig.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/NetworkConfig.kt
@@ -1,0 +1,25 @@
+package work.socialhub.kbsky
+
+open class NetworkConfig {
+
+    /**
+     * Specifies a request timeout in milliseconds.
+     *
+     * https://ktor.io/docs/client-timeout.html
+     */
+    var requestTimeoutMillis: Long? = null
+
+    /**
+     * Specifies a connection timeout in milliseconds.
+     *
+     * https://ktor.io/docs/client-timeout.html
+     */
+    var connectTimeoutMillis: Long? = null
+
+    /**
+     * Specifies a socket timeout (read and write) in milliseconds.
+     *
+     * https://ktor.io/docs/client-timeout.html
+     */
+    var socketTimeoutMillis: Long? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/share/_InternalUtility.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.ATProtocolException
+import work.socialhub.kbsky.NetworkConfig
 import work.socialhub.kbsky.api.entity.share.ErrorResponse
 import work.socialhub.kbsky.api.entity.share.Response
 import work.socialhub.kbsky.auth.AuthProvider
@@ -124,6 +125,7 @@ object _InternalUtility {
         auth: AuthProvider
     ): HttpResponse {
         addContentLabelersHeader(auth.acceptLabelers)
+        // TODO timeout setting
 
         val method = Get.value
         auth.beforeRequestHook(method, this)
@@ -141,6 +143,7 @@ object _InternalUtility {
         auth: AuthProvider
     ): HttpResponse {
         addContentLabelersHeader(auth.acceptLabelers)
+        // TODO timeout setting
 
         val method = Post.value
         auth.beforeRequestHook(method, this)
@@ -160,5 +163,12 @@ object _InternalUtility {
             val labelers = acceptLabelers.joinToString(", ")
             this.header("atproto-accept-labelers", labelers)
         }
+    }
+
+    fun HttpRequest.setTimeouts(config: NetworkConfig) = also {
+
+        this.requestTimeoutMillis = config.requestTimeoutMillis
+        this.connectTimeoutMillis = config.connectTimeoutMillis
+        this.socketTimeoutMillis = config.socketTimeoutMillis
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ dokka = "2.0.0"
 maven-publish = "0.31.0"
 
 [libraries]
-khttpclient = "work.socialhub:khttpclient:0.0.3"
+khttpclient = "work.socialhub:khttpclient:0.0.4-SNAPSHOT"
 ktor-core = "io.ktor:ktor-client-core:3.1.1"
 datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.2"
 coroutines-core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1"


### PR DESCRIPTION
Add timeout option for OAuth.

----

# 背景
- Android で OAuth のトークンリフレッシュを行った際に "invalid_grant: refresh token replayed" のエラーが発生する場合があります。同じリフレッシュトークンを繰り返し使用した場合のエラーです。ちなみに `replayed` の次にリフレッシュしようとすると `invalid_grant: Invalid refresh token` が発生します。
- このエラーの原因の一つが「タイムアウトが短く応答前にエラーになり、リフレッシュ後のトークンを取得・保存できない」ためであると分かりました。Android(Ktor Clientの実装はOkHttp)ではデフォルトのタイムアウトが10秒です。
- トークンリフレッシュについてはタイムアウトを長くすることで取りこぼし(再認証)を防ごうとしています。

# このPRの修正

[khttpclient の PR](https://github.com/uakihir0/khttpclient/pull/40) を前提に、OAuth の AuthConfig にタイムアウト値を指定できるようにしました。例を `OAuthTest.refreshToken` に追加しています。

# スコープ外

- パスワード認証のタイムアウト設定(<- こちらはいずれ Bluesky からなくなるので不要かと思います)
- 通常リクエストのタイムアウト設定
  - _InternalUtility の TODO に書いたとおりですが、どのようにタイムアウト値を指定するか悩ましいので TODO だけ残しています。
  - 動画・画像のアップロードなどのタイムアウトを長くしたいかもしれませんね。


# 動作確認

背景に説明したエラーは希に発生するので動作確認できていませんが、
Android(JVM, Ktor Client の実装は OkHttp)でタイムアウトを短く設定することで本PRのタイムアウトが動作することを確認してみました。

- `connectTimeoutMillis` と `socketTimeoutMillis` については下記の例外が起きることを確認できました。

```
ATProtocolException(message=null, exception=java.net.SocketTimeoutException: Socket timeout has expired [url=https://bsky.social/oauth/token, socket_timeout=1000] ms, status=null, body=null, response=null)
```

```
ATProtocolException(message=null, exception=io.ktor.client.network.sockets.ConnectTimeoutException: Connect timeout has expired [url=https://bsky.social/oauth/token, connect_timeout=10 ms], status=null, body=null, response=null)
```

- `requestTimeoutMillis` は短くしてもエラーにはなりませんでしたが、実用上は問題ないのでこのままにしています。


 
以下は Copilot による本PRの概要です

----

This pull request introduces several updates to the `auth` and `core` modules, focusing on enhancing configuration management and improving timeout settings. The most significant changes include the introduction of a new `NetworkConfig` class, modifications to the `AuthConfig` class to extend `NetworkConfig`, and updates to the `AuthFactory` and `_OAuthResource` classes to utilize these new configurations.

Enhancements to configuration management:

* [`core/src/commonMain/kotlin/work/socialhub/kbsky/NetworkConfig.kt`](diffhunk://#diff-ca8004c01d1f803698e81e50a7ca006ca1d00a56adaee728f18f96499bc65ca8R1-R25): Introduced a new `NetworkConfig` class to manage network-related configurations such as request, connection, and socket timeouts.
* [`auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthConfig.kt`](diffhunk://#diff-eba00e52cef47950b4fb114e056b30ef1d473cd734fae0ab2ac92888fce7aafdR3-R6): Modified the `AuthConfig` class to extend the new `NetworkConfig` class, enabling it to inherit network configuration properties.

Updates to `AuthFactory` and `_OAuthResource` classes:

* [`auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthFactory.kt`](diffhunk://#diff-881f96fd5cbd2f4701260686019473679d8c02e3a5dca67bbbb4e9d6e400effeR7-R12): Added a new `instance` method that accepts an `AuthConfig` parameter and refactored existing methods to utilize this new method.
* [`auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt`](diffhunk://#diff-960518f507a9b25ae7c31333757f299aa3ed264bdac33962462c9cdfd806f1f4R149): Added the `setTimeouts` method call to set request, connection, and socket timeouts based on the `NetworkConfig`.

Test updates:

* [`auth/src/jvmTest/kotlin/work/socialhub/kbsky/auth/OAuthTest.kt`](diffhunk://#diff-bea833ea9700c7635b38d265d5a9ed9e5ee75b3168a7f10c09a1b9e82c526484L77-R89): Updated OAuth tests to utilize the new `AuthConfig` settings, including setting timeouts for the `refreshToken` test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable network timeout options that enhance the reliability of network requests, resulting in smoother authentication flows.
  - Improved authentication setup with a more flexible configuration process for a robust user experience.

- **Refactor**
  - Streamlined the authentication instantiation process to ensure better abstraction and improved handling of OAuth and token requests.
  - Updated internal request handling and tests to align with the enhanced network configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->