### PR TITLE
Exclude "all" and ios/mac targets on Windows

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.konan.target.HostManager
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
@@ -8,11 +10,13 @@ kotlin {
     jvmToolchain(11)
 
     jvm { withJava() }
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosX64()
-    macosArm64()
+    if (HostManager.hostIsMac) {
+        iosX64()
+        iosArm64()
+        iosSimulatorArm64()
+        macosX64()
+        macosArm64()
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.konan.target.HostManager
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
@@ -8,11 +10,13 @@ kotlin {
     jvmToolchain(11)
 
     jvm { withJava() }
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosX64()
-    macosArm64()
+    if (HostManager.hostIsMac) {
+        iosX64()
+        iosArm64()
+        iosSimulatorArm64()
+        macosX64()
+        macosArm64()
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Locale
+
 pluginManagement {
     includeBuild("plugins")
     repositories {
@@ -12,4 +14,9 @@ rootProject.name = "kbsky"
 include("core")
 include("stream")
 include("auth")
-include("all")
+
+// exclude "all" on Windows OS
+val osName = System.getProperty("os.name").lowercase(Locale.getDefault())
+if (osName.contains("mac")) {
+    include("all")
+}

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.konan.target.HostManager
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
@@ -8,11 +10,13 @@ kotlin {
     jvmToolchain(11)
 
     jvm { withJava() }
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosX64()
-    macosArm64()
+    if (HostManager.hostIsMac) {
+        iosX64()
+        iosArm64()
+        iosSimulatorArm64()
+        macosX64()
+        macosArm64()
+    }
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
Windowsで "all" と ios, mac のビルドを行わないようにしました。

## 背景と目的

通常の開発では不要ですが、#147 の対応にあたり必要でした。

ローカルの khttpclient（https://github.com/uakihir0/khttpclient/pull/40 を含む）を使用するために mavenLocal を参照しています。ただしこのライブラリは Windows でビルドしているため、iOS/macOS のアーティファクトが含まれておらず、そのままだと Gradle Sync に失敗します。

そのため本PRでは iOS/macOS のビルドを無効化し、ローカルのライブラリを参照できるようにしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the build configuration to detect the host operating system.
	- Now, platform-specific components are conditionally enabled—macOS-related targets and modules activate only on compatible systems, improving cross-platform consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->