### PR TITLE
Migrate facet cleasses to Data Class

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacet.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacet.kt
@@ -5,11 +5,9 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class RichtextFacet {
-
+data class RichtextFacet(
     @SerialName("\$type")
-    val type: String = BlueskyTypes.RichtextFacet
-
-    var index: RichtextFacetByteSlice? = null
-    var features: MutableList<RichtextFacetFeatureUnion>? = null
-}
+    val type: String = BlueskyTypes.RichtextFacet,
+    var index: RichtextFacetByteSlice? = null,
+    var features: MutableList<RichtextFacetFeatureUnion>? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetByteSlice.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetByteSlice.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
  * A text segment. Start is inclusive, end is exclusive. Indices are for utf8-encoded strings.
  */
 @Serializable
-class RichtextFacetByteSlice {
-    var byteStart: Int? = null
+data class RichtextFacetByteSlice(
+    var byteStart: Int? = null,
     var byteEnd: Int? = null
-}
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetLink.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetLink.kt
@@ -8,14 +8,13 @@ import work.socialhub.kbsky.BlueskyTypes
  * A facet feature for links.
  */
 @Serializable
-class RichtextFacetLink : RichtextFacetFeatureUnion() {
+data class RichtextFacetLink(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var uri: String? = null,
+) : RichtextFacetFeatureUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.RichtextFacet + "#link"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var uri: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetMention.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetMention.kt
@@ -8,15 +8,13 @@ import work.socialhub.kbsky.BlueskyTypes
  * A facet feature for actor mentions.
  */
 @Serializable
-class RichtextFacetMention : RichtextFacetFeatureUnion() {
+data class RichtextFacetMention(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var did: String? = null,
+) : RichtextFacetFeatureUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.RichtextFacet + "#mention"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var did: String? = null
-
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetTag.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetTag.kt
@@ -5,14 +5,13 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class RichtextFacetTag : RichtextFacetFeatureUnion() {
+class RichtextFacetTag(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var tag: String,
+) : RichtextFacetFeatureUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.RichtextFacet + "#tag"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var tag: String
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/facet/FacetList.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/facet/FacetList.kt
@@ -82,8 +82,9 @@ class FacetList(
                     facet.features = mutableListOf()
                     facet.index = slice
 
-                    val tag = RichtextFacetTag()
-                    tag.tag = record.contentText.replace("^#".toRegex(), "")
+                    val tag = RichtextFacetTag(
+                        tag = record.contentText.replace("^#".toRegex(), "")
+                    )
                     facet.features!!.add(tag)
                     facets.add(facet)
                 }


### PR DESCRIPTION
Refactor RichtextFacet classes to use data classes for improved clarity and structure

たまたま必要な部分の data class 化をしました。

#145 と被るので #145 をマージしていただければこちらは破棄でかまいません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Redesigned rich text facet components (mentions, links, tags) for enhanced consistency and efficiency.
  - Streamlined object creation to simplify text processing workflows and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->