### PR TITLE
Confidential client

### DIFF
--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthConfig.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/AuthConfig.kt
@@ -11,4 +11,10 @@ class AuthConfig : NetworkConfig() {
     var tokenEndpoint = "${BSKY_SOCIAL.uri}/oauth/token"
     var authorizationEndpoint = "${BSKY_SOCIAL.uri}/oauth/authorize"
     var pushedAuthorizationRequestEndpoint = "${BSKY_SOCIAL.uri}/oauth/par"
+
+    // Confidential client parameters, if set PAR & token requests will be signed by this key
+    // Note that the keyId must exists in the jwks section of client-metadata.json and the published
+    // public key must match this private key.
+    var confidentialClientKeyId: String? = null
+    var confidentialClientPrivateKey: String? = null
 }

--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/_OAuthResource.kt
@@ -67,7 +67,7 @@ class _OAuthResource(
                     }
                 }
 
-                if (request.keyId?.isNotEmpty() == true) {
+                if (config.confidentialClientKeyId?.isNotEmpty() == true) {
                     // Include the necessary fields for confidential clients
                     val clientAssertion = makeClientAssertion(
                         keyId = request.keyId!!,
@@ -78,13 +78,15 @@ class _OAuthResource(
                                 .privateKeyDecoder(EC.Curve.P256)
                                 .decodeFromByteArrayBlocking(
                                     EC.PrivateKey.Format.DER,
-                                    Base64.decode(context.privateKey!!)
+                                    Base64.decode(config.confidentialClientPrivateKey!!)
                                 )
 
                             privateKey.signatureGenerator(SHA256, SignatureFormat.RAW)
                                 .generateSignatureBlocking(jwtMessage.encodeToByteArray())
                         })
+                    request.keyId = config.confidentialClientKeyId
                     request.clientAssertion = clientAssertion
+                    request.clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
                 }
 
                 HttpRequest()
@@ -121,7 +123,7 @@ class _OAuthResource(
                 context.redirectUri?.let { request.redirectUri = it }
                 context.codeVerifier?.let { request.codeVerifier = it }
 
-                if (request.keyId?.isNotEmpty() == true) {
+                if (config.confidentialClientKeyId?.isNotEmpty() == true) {
                     // Include the necessary fields for confidential clients
                     val clientAssertion = makeClientAssertion(
                         keyId = request.keyId!!,
@@ -132,13 +134,15 @@ class _OAuthResource(
                                 .privateKeyDecoder(EC.Curve.P256)
                                 .decodeFromByteArrayBlocking(
                                     EC.PrivateKey.Format.DER,
-                                    Base64.decode(context.privateKey!!)
+                                    Base64.decode(config.confidentialClientPrivateKey!!)
                                 )
 
                             privateKey.signatureGenerator(SHA256, SignatureFormat.RAW)
                                 .generateSignatureBlocking(jwtMessage.encodeToByteArray())
                         })
+                    request.keyId = config.confidentialClientKeyId
                     request.clientAssertion = clientAssertion
+                    request.clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
                 }
 
                 HttpRequest()


### PR DESCRIPTION
Fixes #151 

I moved confidential client private key & key id into AuthConfig. If set, assertion will be generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced confidential client authentication options to improve secure handling during authorization and token requests. These updates ensure the proper utilization of client credentials for signing requests in OAuth flows, offering better security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->