### PR TITLE
Add chat reactions

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -94,6 +94,7 @@ object BlueskyTypes {
     /// ----------------------------------------------------------------------- ///
 
     // Convo
+    const val ConvoAddReaction = "chat.bsky.convo.addReaction"
     const val ConvoDefs = "chat.bsky.convo.defs"
     const val ConvoDeleteMessageForSelf = "chat.bsky.convo.deleteMessageForSelf"
     const val ConvoGetConvo = "chat.bsky.convo.getConvo"
@@ -103,6 +104,7 @@ object BlueskyTypes {
     const val ConvoLeaveConvo = "chat.bsky.convo.leaveConvo"
     const val ConvoListConvos = "chat.bsky.convo.listConvos"
     const val ConvoMuteConvo = "chat.bsky.convo.muteConvo"
+    const val ConvoRemoveReaction = "chat.bsky.convo.removeReaction"
     const val ConvoSendMessage = "chat.bsky.convo.sendMessage"
     const val ConvoSendMessageBatch = "chat.bsky.convo.sendMessageBatch"
     const val ConvoUnmuteConvo = "chat.bsky.convo.unmuteConvo"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/ConvoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/ConvoResource.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kbsky.api.chat.bsky
 
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoForMembersRequest
@@ -16,6 +18,8 @@ import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLeaveConvoRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLeaveConvoResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoMuteConvoRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoMuteConvoResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoRemoveReactionRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoRemoveReactionResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoSendMessageRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoSendMessageResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoUnmuteConvoRequest
@@ -108,4 +112,17 @@ interface ConvoResource {
         request: ConvoLeaveConvoRequest
     ): Response<ConvoLeaveConvoResponse>
 
+    /**
+     * chat.bsky.convo.addReaction
+     */
+    fun addReaction(
+        request: ConvoAddReactionRequest
+    ): Response<ConvoAddReactionResponse>
+
+    /**
+     * chat.bsky.convo.removeReaction
+     */
+    fun removeReaction(
+        request: ConvoRemoveReactionRequest
+    ): Response<ConvoRemoveReactionResponse>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAddReactionRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAddReactionRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+
+data class ConvoAddReactionRequest(
+    override val auth: AuthProvider,
+    val convoId: String,
+    val messageId: String,
+    val value: String,
+) : AuthRequest(auth), MapRequest {
+
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("messageId", messageId)
+            it.addParam("value", value)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAddReactionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAddReactionResponse.kt
@@ -1,0 +1,9 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageView
+
+@Serializable
+data class ConvoAddReactionResponse(
+    val message: ConvoDefsMessageView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoRemoveReactionRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoRemoveReactionRequest.kt
@@ -1,0 +1,21 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+
+data class ConvoRemoveReactionRequest(
+    override val auth: AuthProvider,
+    val convoId: String,
+    val messageId: String,
+    val value: String,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("messageId", messageId)
+            it.addParam("value", value)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoRemoveReactionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoRemoveReactionResponse.kt
@@ -1,0 +1,9 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageView
+
+@Serializable
+data class ConvoRemoveReactionResponse(
+    val message: ConvoDefsMessageView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/AuthRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/AuthRequest.kt
@@ -3,6 +3,6 @@ package work.socialhub.kbsky.api.entity.share
 import work.socialhub.kbsky.auth.AuthProvider
 
 open class AuthRequest(
-    val auth: AuthProvider
+    open val auth: AuthProvider
 )
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/_ConvoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/_ConvoResource.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.runBlocking
 import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.api.chat.bsky.ConvoResource
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoForMembersRequest
@@ -20,6 +22,8 @@ import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLeaveConvoRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLeaveConvoResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoMuteConvoRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoMuteConvoResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoRemoveReactionRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoRemoveReactionResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoSendMessageRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoSendMessageResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoUnmuteConvoRequest
@@ -155,6 +159,28 @@ class _ConvoResource(
 
         return proceedPost(
             BlueskyTypes.ConvoLeaveConvo,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun addReaction(
+        request: ConvoAddReactionRequest
+    ): Response<ConvoAddReactionResponse> {
+
+        return proceedPost(
+            BlueskyTypes.ConvoAddReaction,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun removeReaction(
+        request: ConvoRemoveReactionRequest
+    ): Response<ConvoRemoveReactionResponse> {
+
+        return proceedPost(
+            BlueskyTypes.ConvoRemoveReaction,
             request.toMappedJson(),
             request.auth,
         )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoView.kt
@@ -8,10 +8,11 @@ import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
  */
 @Serializable
 data class ConvoDefsConvoView(
-    var id: String,
-    var rev: String,
-    var members: List<ActorDefsProfileViewBasic>,
-    var lastMessage: ConvoDefsMessageUnion? = null,
-    var muted: Boolean = false,
-    var unreadCount: Int = 0,
+    val id: String,
+    val rev: String,
+    val members: List<ActorDefsProfileViewBasic>,
+    val lastMessage: ConvoDefsMessageUnion? = null,
+    val lastReaction: ConvoDefsMessageAndReactionView? = null,
+    val muted: Boolean = false,
+    val unreadCount: Int = 0,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoView.kt
@@ -7,11 +7,11 @@ import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
  * chat.bsky.convo.defs#convoView
  */
 @Serializable
-class ConvoDefsConvoView {
-    lateinit var id: String
-    lateinit var rev: String
-    lateinit var members: List<ActorDefsProfileViewBasic>
-    var lastMessage: ConvoDefsMessageUnion? = null
-    var muted: Boolean = false
-    var unreadCount: Int = 0
-}
+data class ConvoDefsConvoView(
+    var id: String,
+    var rev: String,
+    var members: List<ActorDefsProfileViewBasic>,
+    var lastMessage: ConvoDefsMessageUnion? = null,
+    var muted: Boolean = false,
+    var unreadCount: Int = 0,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsDeletedMessageView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsDeletedMessageView.kt
@@ -5,17 +5,15 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ConvoDefsDeletedMessageView : ConvoDefsMessageUnion() {
-
+data class ConvoDefsDeletedMessageView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var id: String,
+    var rev: String,
+    var sender: ConvoDefsMessageViewSender,
+    var sentAt: String,
+) : ConvoDefsMessageUnion() {
     companion object {
         const val TYPE = BlueskyTypes.ConvoDefs + "#deletedMessageView"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var id: String
-    lateinit var rev: String
-    lateinit var sender: ConvoDefsMessageViewSender
-    lateinit var sentAt: String
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogAddReaction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogAddReaction.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+class ConvoDefsLogAddReaction(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val rev: String,
+    val convoId: String,
+    val message: ConvoDefsMessageUnion,
+    val reaction: ConvoDefsReactionView,
+) : ConvoDefsLogUnion() {
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#logAddReaction"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogBeginConvo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogBeginConvo.kt
@@ -5,15 +5,13 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ConvoDefsLogBeginConvo : ConvoDefsLogUnion() {
-
+data class ConvoDefsLogBeginConvo(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var rev: String,
+    var convoId: String,
+) : ConvoDefsLogUnion() {
     companion object {
         const val TYPE = BlueskyTypes.ConvoDefs + "#logBeginConvo"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var rev: String
-    lateinit var convoId: String
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogCreateMessage.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogCreateMessage.kt
@@ -5,16 +5,15 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ConvoDefsLogCreateMessage : ConvoDefsLogUnion() {
+data class ConvoDefsLogCreateMessage(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var rev: String,
+    var convoId: String,
+    var message: ConvoDefsMessageUnion,
+) : ConvoDefsLogUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ConvoDefs + "#logCreateMessage"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var rev: String
-    lateinit var convoId: String
-    lateinit var message: ConvoDefsMessageUnion
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogDeleteMessage.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogDeleteMessage.kt
@@ -5,16 +5,14 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ConvoDefsLogDeleteMessage : ConvoDefsLogUnion() {
-
+data class ConvoDefsLogDeleteMessage(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var rev: String,
+    var convoId: String,
+    var message: ConvoDefsMessageUnion,
+) : ConvoDefsLogUnion() {
     companion object {
         const val TYPE = BlueskyTypes.ConvoDefs + "#logDeleteMessage"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var rev: String
-    lateinit var convoId: String
-    lateinit var message: ConvoDefsMessageUnion
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogLeaveConvo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogLeaveConvo.kt
@@ -5,15 +5,14 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ConvoDefsLogLeaveConvo : ConvoDefsLogUnion() {
+data class ConvoDefsLogLeaveConvo(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var rev: String,
+    var convoId: String,
+) : ConvoDefsLogUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ConvoDefs + "#logLeaveConvo"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var rev: String
-    lateinit var convoId: String
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogReadMessage.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogReadMessage.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+data class ConvoDefsLogReadMessage(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var rev: String,
+    var convoId: String,
+    var message: ConvoDefsMessageUnion,
+) : ConvoDefsLogUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#logReadMessage"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogRemoveReaction.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogRemoveReaction.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+class ConvoDefsLogRemoveReaction(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val rev: String,
+    val convoId: String,
+    val message: ConvoDefsMessageUnion,
+    val reaction: ConvoDefsReactionView,
+) : ConvoDefsLogUnion() {
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#logRemoveReaction"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogUnion.kt
@@ -13,7 +13,7 @@ import work.socialhub.kbsky.util.json.ChatConvoDefsLogUnionSerializer
 @Serializable(with = ChatConvoDefsLogUnionSerializer::class)
 abstract class ConvoDefsLogUnion {
     @SerialName("\$type")
-    abstract var type: String
+    abstract val type: String
 
     val asBeginConvo get() = this as? ConvoDefsLogBeginConvo
     val asLeaveConvo get() = this as? ConvoDefsLogLeaveConvo

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsLogUnion.kt
@@ -9,6 +9,9 @@ import work.socialhub.kbsky.util.json.ChatConvoDefsLogUnionSerializer
  * @see ConvoDefsLogLeaveConvo
  * @see ConvoDefsLogCreateMessage
  * @see ConvoDefsLogDeleteMessage
+ * @see ConvoDefsLogReadMessage
+ * @see ConvoDefsLogAddReaction
+ * @see ConvoDefsLogRemoveReaction
  */
 @Serializable(with = ChatConvoDefsLogUnionSerializer::class)
 abstract class ConvoDefsLogUnion {
@@ -19,4 +22,7 @@ abstract class ConvoDefsLogUnion {
     val asLeaveConvo get() = this as? ConvoDefsLogLeaveConvo
     val asCreateMessage get() = this as? ConvoDefsLogCreateMessage
     val asDeleteMessage get() = this as? ConvoDefsLogDeleteMessage
+    val asReadMessage get() = this as? ConvoDefsLogReadMessage
+    val asAddReaction get() = this as? ConvoDefsLogAddReaction
+    val asRemoveReaction get() = this as? ConvoDefsLogRemoveReaction
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageAndReactionView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageAndReactionView.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+data class ConvoDefsMessageAndReactionView(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val message: ConvoDefsMessageView,
+    val reaction: ConvoDefsReactionView,
+) : ConvoDefsMessageUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#messageAndReactionView"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageAndReactionView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageAndReactionView.kt
@@ -7,11 +7,10 @@ import work.socialhub.kbsky.BlueskyTypes
 @Serializable
 data class ConvoDefsMessageAndReactionView(
     @SerialName("\$type")
-    override val type: String = TYPE,
+    val type: String = TYPE,
     val message: ConvoDefsMessageView,
     val reaction: ConvoDefsReactionView,
-) : ConvoDefsMessageUnion() {
-
+) {
     companion object {
         const val TYPE = BlueskyTypes.ConvoDefs + "#messageAndReactionView"
     }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageInput.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageInput.kt
@@ -5,9 +5,8 @@ import work.socialhub.kbsky.model.app.bsky.embed.EmbedUnion
 import work.socialhub.kbsky.model.app.bsky.richtext.RichtextFacet
 
 @Serializable
-class ConvoDefsMessageInput {
-
-    lateinit var text: String
-    var facets: List<RichtextFacet>? = null
-    var embed: EmbedUnion? = null
-}
+data class ConvoDefsMessageInput(
+    var text: String,
+    var facets: List<RichtextFacet>? = null,
+    var embed: EmbedUnion? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageUnion.kt
@@ -7,12 +7,14 @@ import work.socialhub.kbsky.util.json.ChatConvoDefsMessageUnionSerializer
 /**
  * @see ConvoDefsMessageView
  * @see ConvoDefsDeletedMessageView
+ * @see ConvoDefsMessageAndReactionView
  */
 @Serializable(with = ChatConvoDefsMessageUnionSerializer::class)
 abstract class ConvoDefsMessageUnion {
     @SerialName("\$type")
-    abstract var type: String
+    abstract val type: String
 
     val asMessageView get() = this as? ConvoDefsMessageView
     val asDeletedMessageView get() = this as? ConvoDefsDeletedMessageView
+    val asMessageAndReactionView get() = this as? ConvoDefsMessageAndReactionView
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageUnion.kt
@@ -7,7 +7,6 @@ import work.socialhub.kbsky.util.json.ChatConvoDefsMessageUnionSerializer
 /**
  * @see ConvoDefsMessageView
  * @see ConvoDefsDeletedMessageView
- * @see ConvoDefsMessageAndReactionView
  */
 @Serializable(with = ChatConvoDefsMessageUnionSerializer::class)
 abstract class ConvoDefsMessageUnion {
@@ -16,5 +15,4 @@ abstract class ConvoDefsMessageUnion {
 
     val asMessageView get() = this as? ConvoDefsMessageView
     val asDeletedMessageView get() = this as? ConvoDefsDeletedMessageView
-    val asMessageAndReactionView get() = this as? ConvoDefsMessageAndReactionView
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageView.kt
@@ -7,21 +7,19 @@ import work.socialhub.kbsky.model.app.bsky.richtext.RichtextFacet
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-class ConvoDefsMessageView : ConvoDefsMessageUnion() {
+data class ConvoDefsMessageView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var id: String,
+    var rev: String,
+    var text: String,
+    var facets: List<RichtextFacet>? = null,
+    var embed: RecordUnion? = null,
+    var sender: ConvoDefsMessageViewSender,
+    var sentAt: String,
+) : ConvoDefsMessageUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ConvoDefs + "#messageView"
     }
-
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var id: String
-    lateinit var rev: String
-    lateinit var text: String
-    lateinit var sender: ConvoDefsMessageViewSender
-    lateinit var sentAt: String
-
-    var facets: List<RichtextFacet>? = null
-    var embed: RecordUnion? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageView.kt
@@ -9,14 +9,15 @@ import work.socialhub.kbsky.model.share.RecordUnion
 @Serializable
 data class ConvoDefsMessageView(
     @SerialName("\$type")
-    override var type: String = TYPE,
-    var id: String,
-    var rev: String,
-    var text: String,
-    var facets: List<RichtextFacet>? = null,
-    var embed: RecordUnion? = null,
-    var sender: ConvoDefsMessageViewSender,
-    var sentAt: String,
+    override val type: String = TYPE,
+    val id: String,
+    val rev: String,
+    val text: String,
+    val facets: List<RichtextFacet>? = null,
+    val embed: RecordUnion? = null,
+    val reactions: List<ConvoDefsReactionView> = emptyList(),
+    val sender: ConvoDefsMessageViewSender,
+    val sentAt: String,
 ) : ConvoDefsMessageUnion() {
 
     companion object {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageViewSender.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageViewSender.kt
@@ -3,7 +3,6 @@ package work.socialhub.kbsky.model.chat.bsky.convo
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ConvoDefsMessageViewSender {
-
-    lateinit var did: String
-}
+data class ConvoDefsMessageViewSender(
+    var did: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsReactionView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsReactionView.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+import kotlinx.serialization.Serializable
+
+/**
+ * chat.bsky.convo.defs#reactionView
+ */
+@Serializable
+data class ConvoDefsReactionView(
+    val value: String,
+    val sender: ConvoDefsReactionViewSender,
+    val createdAt: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsReactionViewSender.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsReactionViewSender.kt
@@ -1,0 +1,11 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+import kotlinx.serialization.Serializable
+
+/**
+ * chat.bsky.convo.defs#reactionViewSender
+ */
+@Serializable
+data class ConvoDefsReactionViewSender(
+    val did: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsLogUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsLogUnionSerializer.kt
@@ -4,10 +4,13 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogAddReaction
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogBeginConvo
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogCreateMessage
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogDeleteMessage
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogLeaveConvo
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogReadMessage
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogRemoveReaction
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogUnion
 import work.socialhub.kbsky.util.json.JsonElementUtil.type
 
@@ -24,6 +27,9 @@ object ChatConvoDefsLogUnionSerializer :
             ConvoDefsLogLeaveConvo.TYPE -> ConvoDefsLogLeaveConvo.serializer()
             ConvoDefsLogCreateMessage.TYPE -> ConvoDefsLogCreateMessage.serializer()
             ConvoDefsLogDeleteMessage.TYPE -> ConvoDefsLogDeleteMessage.serializer()
+            ConvoDefsLogReadMessage.TYPE -> ConvoDefsLogReadMessage.serializer()
+            ConvoDefsLogAddReaction.TYPE -> ConvoDefsLogAddReaction.serializer()
+            ConvoDefsLogRemoveReaction.TYPE -> ConvoDefsLogRemoveReaction.serializer()
             else -> {
                 println("[Warning] Unknown Item type: $type (ChatConvoDefsLogUnion)")
                 Unknown.serializer()

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
@@ -7,7 +7,8 @@ import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
 import work.socialhub.kbsky.model.app.bsky.feed.FeedPost
 import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
-import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageView
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsLogUnion
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageUnion
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsReactionView
 import work.socialhub.kbsky.model.share.RecordUnion
 
@@ -83,12 +84,23 @@ object Printer {
         }
     }
 
-    fun AbstractTest.dump(message: ConvoDefsMessageView, sp: String = "") {
-        println("${sp}|CONVO MESSAGE|-----------------------------------------")
-        println("${sp}ID> ${message.id}")
-        println("${sp}TEXT> ${message.text}")
-        message.reactions.forEach {
-            dump(it, "$sp  ")
+    fun AbstractTest.dump(messageUnion: ConvoDefsMessageUnion, sp: String = "") {
+        messageUnion.asMessageView?.let { message ->
+            println("${sp}|CONVO MESSAGE|-----------------------------------------")
+            println("${sp}ID> ${message.id}")
+            println("${sp}TEXT> ${message.text}")
+            message.reactions.forEach {
+                dump(it, "$sp  ")
+            }
+        }
+        messageUnion.asDeletedMessageView?.let { message ->
+            println("${sp}|CONVO DELETED MESSAGE|-----------------------------------------")
+            println("${sp}ID> ${message.id}")
+        }
+        messageUnion.asMessageAndReactionView?.let { message ->
+            println("${sp}|CONVO MESSAGE AND REACTION|-----------------------------------------")
+            dump(message.message, "$sp  ")
+            dump(message.reaction, "$sp  ")
         }
     }
 
@@ -102,5 +114,39 @@ object Printer {
         println("${sp}|CONVO ACTOR|-----------------------------------------")
         println("${sp}DID> ${actor.did}")
         println("${sp}DISPLAY NAME> ${actor.displayName}")
+    }
+
+    fun AbstractTest.dump(log: ConvoDefsLogUnion, sp: String = "") {
+        println("${sp}|CONVO LOG|-----------------------------------------")
+        println("${sp}TYPE> ${log.type}")
+
+        log.asBeginConvo?.let {
+            println("${sp}CONVERSATION ID> ${it.convoId}")
+        }
+        log.asLeaveConvo?.let {
+            println("${sp}CONVERSATION ID> ${it.convoId}")
+        }
+        log.asCreateMessage?.let {
+            println("${sp}CONVERSATION ID> ${it.convoId}")
+            dump(it.message, "$sp  ")
+        }
+        log.asDeleteMessage?.let {
+            println("${sp}CONVERSATION ID> ${it.convoId}")
+            dump(it.message, "$sp  ")
+        }
+        log.asReadMessage?.let {
+            println("${sp}CONVERSATION ID> ${it.convoId}")
+            dump(it.message, "$sp  ")
+        }
+        log.asAddReaction?.let {
+            println("${sp}CONVERSATION ID> ${it.convoId}")
+            dump(it.message, "$sp  ")
+            dump(it.reaction, "$sp  ")
+        }
+        log.asRemoveReaction?.let {
+            println("${sp}CONVERSATION ID> ${it.convoId}")
+            dump(it.message, "$sp  ")
+            dump(it.reaction, "$sp  ")
+        }
     }
 }

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
@@ -97,11 +97,6 @@ object Printer {
             println("${sp}|CONVO DELETED MESSAGE|-----------------------------------------")
             println("${sp}ID> ${message.id}")
         }
-        messageUnion.asMessageAndReactionView?.let { message ->
-            println("${sp}|CONVO MESSAGE AND REACTION|-----------------------------------------")
-            dump(message.message, "$sp  ")
-            dump(message.reaction, "$sp  ")
-        }
     }
 
     fun AbstractTest.dump(reaction: ConvoDefsReactionView, sp: String = "") {

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
@@ -74,6 +74,10 @@ object Printer {
         convo.lastMessage?.asMessageView?.let {
             dump(it, "$sp  ")
         }
+        convo.lastReaction?.reaction?.let {
+            println("${sp}LAST REACTION> ${it.value}")
+        }
+        println("${sp}MEMBERS> ${convo.members.size}")
         convo.members.forEach {
             dump(it, "$sp  ")
         }

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/Printer.kt
@@ -8,6 +8,7 @@ import work.socialhub.kbsky.model.app.bsky.feed.FeedPost
 import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageView
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsReactionView
 import work.socialhub.kbsky.model.share.RecordUnion
 
 object Printer {
@@ -82,6 +83,15 @@ object Printer {
         println("${sp}|CONVO MESSAGE|-----------------------------------------")
         println("${sp}ID> ${message.id}")
         println("${sp}TEXT> ${message.text}")
+        message.reactions.forEach {
+            dump(it, "$sp  ")
+        }
+    }
+
+    fun AbstractTest.dump(reaction: ConvoDefsReactionView, sp: String = "") {
+        println("${sp}|CONVO REACTION|-----------------------------------------")
+        println("${sp}VALUE> ${reaction.value}")
+        println("${sp}SENDER DID> ${reaction.sender.did}")
     }
 
     fun AbstractTest.dump(actor: ActorDefsProfileViewBasic, sp: String = "") {

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/GetLogTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/GetLogTest.kt
@@ -1,0 +1,32 @@
+package work.socialhub.kbsky.chat.bsky.convo
+
+import work.socialhub.kbsky.AbstractTest
+
+class GetLogTest : AbstractTest() {
+
+//    companion object {
+//        const val CURSOR = "<SPECIFY LAST REV>"
+//    }
+//
+//    @Test
+//    fun testGetLog() {
+//        val convos = BlueskyFactory
+//            .instance().also {
+//                it.server()
+//                    .getSession(
+//                        AuthRequest(auth())
+//                    )
+//            }
+//            .convo()
+//            .getLog(
+//                ConvoGetLogRequest(auth()).also {
+//                    it.cursor = CURSOR
+//                }
+//            )
+//
+//        println("logs: ${convos.data.logs.size}")
+//        convos.data.logs.forEach {
+//            dump(it)
+//        }
+//    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/ReactionTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/convo/ReactionTest.kt
@@ -1,0 +1,61 @@
+package work.socialhub.kbsky.chat.bsky.convo
+
+import work.socialhub.kbsky.AbstractTest
+import kotlin.test.Test
+
+class ReactionTest : AbstractTest() {
+
+    @Test
+    fun testAddReaction() {
+        // TODO Specify the convoId and messageId of the message you want to add a reaction to
+//        val convoId = "3kt574hlxf72q"
+//        val messageId = "3lmij5ilmwq2c"
+//        val value = "🙌"
+//
+//        val message = BlueskyFactory
+//            .instance().also {
+//                it.server()
+//                    .getSession(
+//                        AuthRequest(auth())
+//                    )
+//            }
+//            .convo()
+//            .addReaction(
+//                ConvoAddReactionRequest(
+//                    auth = auth(),
+//                    convoId = convoId,
+//                    messageId = messageId,
+//                    value = value,
+//                )
+//            )
+//
+//        dump(message.data.message)
+    }
+
+    @Test
+    fun testRemoveReaction() {
+        // TODO Specify the convoId and messageId of the message you want to remove a reaction from
+//        val convoId = "3kt574hlxf72q"
+//        val messageId = "3lmij5ilmwq2c"
+//        val value = "🙌"
+//
+//        val message = BlueskyFactory
+//            .instance().also {
+//                it.server()
+//                    .getSession(
+//                        AuthRequest(auth())
+//                    )
+//            }
+//            .convo()
+//            .removeReaction(
+//                ConvoRemoveReactionRequest(
+//                    auth = auth(),
+//                    convoId = convoId,
+//                    messageId = messageId,
+//                    value = value,
+//                )
+//            )
+//
+//        dump(message.data.message)
+    }
+}


### PR DESCRIPTION
Add chat reaction feature.

----

- ConvoDefs 系は data class に移行しました
- リアクションの表示および追加・削除に対応しました
- `GetLogTest`, `ReactionTest` はテストアカウント用のデータが必要なのでコメントアウトしてあります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced conversation reaction support, allowing users to add or remove reactions on chat messages.
  
- **Refactor**
  - Enhanced the underlying data structures for messages and logs to improve consistency and reliability in the chat experience.
  
- **Tests**
  - Added new tests for conversation logging and reaction functionalities to ensure robust and accurate integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->