### PR TITLE
Allow unauthenticated requests

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/auth/UnauthenticatedAuthProvider.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/auth/UnauthenticatedAuthProvider.kt
@@ -1,0 +1,21 @@
+package work.socialhub.kbsky.auth
+
+import work.socialhub.khttpclient.HttpRequest
+import work.socialhub.khttpclient.HttpResponse
+
+class UnauthenticatedAuthProvider: AuthProvider {
+
+    override fun beforeRequestHook(method: String, request: HttpRequest) {
+        // Nothing to do
+    }
+
+    override fun afterRequestHook(method: String, request: HttpRequest, response: HttpResponse): Boolean {
+        // Do nothing here
+        return false
+    }
+
+    override val did: String = ""
+    override val pdsDid: String = ""
+    override var acceptLabelers: List<String> = emptyList()
+
+}


### PR DESCRIPTION
Hi, some endpoints are fully public and do not require authenticated calls (eg. to fetch an actor profile via an `ActorGetProfileRequest` using `Service.BSKY_APP_PUBLIC`). 

This PR introduces an `UnauthenticatedAuthProvider` that allows to send fully unauthenticated requests to public endpoints.

eg. (in java)
```java 
var resolveRequest = new ActorGetProfileRequest(new UnauthenticatedAuthProvider());
resolveRequest.setActor(handle);

var response = BlueskyFactory.INSTANCE.instance(Service.BSKY_APP_PUBLIC.getUri())
    .actor()
    .getProfile(resolveRequest)
    .getData();
```