### PR TITLE
Not raise exception but log when Jetstream fields are dropped #117

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/JetStreamClient.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/JetStreamClient.kt
@@ -3,6 +3,7 @@ package work.socialhub.kbsky.stream.entity.app.bsky
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.MissingFieldException
 import work.socialhub.kbsky.internal.share._InternalUtility
 import work.socialhub.kbsky.stream.entity.app.bsky.callback.JetStreamEventCallback
 import work.socialhub.kbsky.stream.entity.app.bsky.model.Event
@@ -66,6 +67,10 @@ class JetStreamClient(
                 val event = _InternalUtility.fromJson<Event>(text)
                 it.onEvent(event)
             }
+        } catch (e: MissingFieldException) {
+            println("Missing field:\n")
+            e.missingFields.forEach { text -> println(text) }
+            println("Raw Text:\n" + text)
         } catch (e: Exception) {
             errorCallback?.onError(e)
         }


### PR DESCRIPTION
Add detailed exception and logging.
But a way of error logging may not be appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for missing fields during event processing, providing clearer messages when required data is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->