### PR TITLE
add swift package build.

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -23,12 +23,12 @@ jobs:
     - name: Build with Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
-        arguments: build -x core:jvmTest -x stream:jvmTest -x auth:jvmTest
+        arguments: build -x check
 
     - name: Publish to Repsy
       uses: gradle/actions/setup-gradle@v3
       with:
-        arguments: publishAllPublicationsToMavenRepository -x core:jvmTest -x stream:jvmTest -x auth:jvmTest
+        arguments: publishAllPublicationsToMavenRepository -x check
       env:
         USERNAME: ${{ secrets.REPSY_USERNAME }}
         PASSWORD: ${{ secrets.REPSY_PASSWORD }}

--- a/.github/workflows/swiftpackage.yml
+++ b/.github/workflows/swiftpackage.yml
@@ -1,0 +1,41 @@
+name: Make SwiftPackage
+on: [push]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Create SwiftPackage
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          arguments: all:createSwiftPackage -x check
+
+      - name: Set Project Version
+        run: |
+          project_version=$(./gradlew version --no-daemon --console=plain -q)
+          echo "PROJECT_VERSION=$project_version" >> $GITHUB_ENV
+
+      - name: Commit Package to GitHub
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config --global user.email "a.urusihara@gmail.com"
+          git config --global user.name "Akihiro Urushihara"
+          cd ./all/swiftpackage/
+          cp ../../docs/spm/README.md ./README.md
+          cp ../../docs/spm/README_ja.md ./README_ja.md
+          git init
+          git add --all
+          git commit -m "by GitHub Action CI (SHA ${GITHUB_SHA})"
+          git remote add origin https://${GH_TOKEN}@github.com/uakihir0/kbsky-spm.git
+          git push -f origin HEAD:${{ env.PROJECT_VERSION }}
+          git push -f origin HEAD:main

--- a/all/.gitignore
+++ b/all/.gitignore
@@ -1,1 +1,2 @@
+swiftpackage/
 kbsky.podspec

--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.cocoapods)
+    alias(libs.plugins.swiftpackage)
     id("module.publications")
 }
 
@@ -42,6 +43,15 @@ kotlin {
             api(project(":core"))
             api(project(":stream"))
         }
+    }
+}
+
+multiplatformSwiftPackage {
+    swiftToolsVersion("5.7")
+    targetPlatforms {
+        // baseline 2020
+        iOS { v("15") }
+        macOS { v("12.0") }
     }
 }
 

--- a/docs/spm/README.md
+++ b/docs/spm/README.md
@@ -12,7 +12,7 @@ Please direct any issues or pull requests to [kbsky].
 This repository does not have its own versioning.
 Instead, branches corresponding to the versions of [kbsky] are provided.
 To use a specific version of [kbsky], specify the corresponding branch of this repository.
-Check the [list of branches](https://github.com/uakihir0/kbsky-cocoapods/branches) to find the branch matching your desired version.
+Check the [list of branches](https://github.com/uakihir0/kbsky-spm/branches) to find the branch matching your desired version.
 
 ### How to Make Requests
 

--- a/docs/spm/README.md
+++ b/docs/spm/README.md
@@ -1,0 +1,46 @@
+# kbsky SPM
+
+This repository is the Swift Package repository for [kbsky].
+[kbsky] is a Bluesky/ATProtocol client library built using Kotlin Multiplatform.
+As a result, it can be built and used on Apple devices such as iOS.
+Here, we distribute the library built as an XCFramework via Swift Package.
+Additionally, this repository is automatically committed to via GitHub Actions from [kbsky].
+Please direct any issues or pull requests to [kbsky].
+
+## Usage
+
+This repository does not have its own versioning.
+Instead, branches corresponding to the versions of [kbsky] are provided.
+To use a specific version of [kbsky], specify the corresponding branch of this repository.
+Check the [list of branches](https://github.com/uakihir0/kbsky-cocoapods/branches) to find the branch matching your desired version.
+
+### How to Make Requests
+
+Although it is also usable from Objective-C, below is an example of how to use it in Swift.
+For more detailed usage instructions, please refer to the [kbsky] README.
+
+```swift
+let response = BskyFactory()
+  .atproto(apiUri: "https://bsky.social/")
+  .repo()
+  .getRecord(request:
+    CoreRepoGetRecordRequest(
+      repo: "uakihir0.com",
+      collection: "app.bsky.feed.post",
+      rkey: nil,
+      uri: "at://did:plc:bwdof2anluuf5wmfy2upgulw/app.bsky.feed.post/3jqcyfp3zt22s"
+    )
+  )
+
+print(response.data?.uri ?? "nil") 
+```
+
+## License
+
+MIT License
+
+## Author
+
+[Akihiro Urushihara](https://github.com/uakihir0)
+
+[kbsky]: https://github.com/uakihir0/kbsky

--- a/docs/spm/README_ja.md
+++ b/docs/spm/README_ja.md
@@ -1,0 +1,43 @@
+# kbsky SPM
+
+本レポジトリは、[kbsky] の SwiftPackage レポジトリです。[kbsky] は Kotlin Multiplatform を用いて作成された Bluesky/ATProtocol クライアントライブラリです。
+そのため、iOS 等の Apple Device でも使用でもビルドして使用することができます。ここでは、XCFramework としてビルドしたものを SwiftPackage 経由で配布しています。
+また、このレポジトリは [kbsky] の GitHub Actions によって自動コミットされています。issue や pull request は [kbsky] にお願いします。
+
+## 使用方法
+
+本レポジトリにはバージョンは存在せず、[kbsky] のバージョンと一致するブランチが存在します。
+どのバージョンの [kbsky] を使用するかは、本レポジトリのブランチを指定することで決定します。
+[ブランチ一覧](https://github.com/uakihir0/kbsky-cocoapods/branches) からバージョンに対応するブランチを確認してください。
+
+### リクエスト方法
+
+Objective-C でも使用可能ですが、以下に Swift での使用方法を記載します。
+詳しい使い方については、[kbsky] の README も合わせて確認してください。
+
+```swift
+let response = BskyFactory()
+  .atproto(apiUri: "https://bsky.social/")
+  .repo()
+  .getRecord(request:
+    CoreRepoGetRecordRequest(
+      repo: "uakihir0.com",
+      collection: "app.bsky.feed.post",
+      rkey: nil,
+      uri: "at://did:plc:bwdof2anluuf5wmfy2upgulw/app.bsky.feed.post/3jqcyfp3zt22s"
+    )
+  )
+
+print(response.data?.uri ?? "nil") 
+```
+
+## ライセンス
+
+MIT License
+
+## 作者
+
+[Akihiro Urushihara](https://github.com/uakihir0)
+
+
+[kbsky]: https://github.com/uakihir0/kbsky

--- a/docs/spm/README_ja.md
+++ b/docs/spm/README_ja.md
@@ -8,7 +8,7 @@
 
 本レポジトリにはバージョンは存在せず、[kbsky] のバージョンと一致するブランチが存在します。
 どのバージョンの [kbsky] を使用するかは、本レポジトリのブランチを指定することで決定します。
-[ブランチ一覧](https://github.com/uakihir0/kbsky-cocoapods/branches) からバージョンに対応するブランチを確認してください。
+[ブランチ一覧](https://github.com/uakihir0/kbsky-spm/branches) からバージョンに対応するブランチを確認してください。
 
 ### リクエスト方法
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,4 +26,5 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+swiftpackage = "io.github.luca992.multiplatform-swiftpackage:2.2.4"
 git-versioning = "me.qoomon.git-versioning:6.4.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for building and publishing a Swift Package for the library, including compatibility with iOS 15 and macOS 12.0.
  - Introduced a new automated workflow to create and publish the Swift Package to a separate repository on each push.
- **Documentation**
  - Added English and Japanese README files explaining Swift Package usage, versioning, and integration instructions.
- **Chores**
  - Updated configuration to ignore the generated Swift Package directory in version control.
  - Adjusted workflow steps for more streamlined build and publish processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->