### PR TITLE
Fix comment for JetStreamSubscribeRequest cursor

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/api/entity/app/bsky/JetStreamSubscribeRequest.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/api/entity/app/bsky/JetStreamSubscribeRequest.kt
@@ -28,7 +28,7 @@ class JetStreamSubscribeRequest {
 
     /**
      * A unix microseconds timestamp cursor to begin playback from.
-     * n absent cursor or a cursor from the future will result in live-tail operation.
+     * An absent cursor or a cursor from the future will result in live-tail operation.
      * When reconnecting, use the time_us from your most recently processed event
      * and maybe provide a negative buffer (i.e. subtract a few seconds) to ensure gapless playback
      */


### PR DESCRIPTION
## Summary
- fix grammar in JetStreamSubscribeRequest comment

## Testing
- `./gradlew --console=plain test --no-daemon` *(fails: Task 'test' not found)*

------
https://chatgpt.com/codex/tasks/task_e_684946dc0be0832a95bb355c7d4cebbf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the comment for the cursor property to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->