### PR TITLE
Fix typo in JetStreamSubscribeRequest comment

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/api/entity/app/bsky/JetStreamSubscribeRequest.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/api/entity/app/bsky/JetStreamSubscribeRequest.kt
@@ -42,7 +42,7 @@ class JetStreamSubscribeRequest {
     // var compress: Boolean = false
 
     /**
-     * Set to true to pause replay/live-tail until the server recevies
+     * Set to true to pause replay/live-tail until the server receives
      * a SubscriberOptionsUpdatePayload over the socket in a Subscriber Sourced Message
      */
     var requireHello: Boolean? = null


### PR DESCRIPTION
## Summary
- correct spelling in requireHello comment

## Testing
- `./gradlew test` *(fails: task not found)*
- `./gradlew assemble` *(fails: no Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684946c2486c832a967da2e2efb4d2b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a spelling mistake in the documentation for the `requireHello` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->