### PR TITLE
Fix missing SLF4J provider

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
         jvmTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.cryptography.jdk)
+            implementation(libs.slf4j.simple)
         }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,6 +34,10 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
         }
+
+        jvmTest.dependencies {
+            implementation(libs.slf4j.simple)
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ cryptography-bom = "dev.whyoleg.cryptography:cryptography-bom:0.4.0"
 cryptography-core = { module = "dev.whyoleg.cryptography:cryptography-core" }
 cryptography-openssl = { module = "dev.whyoleg.cryptography:cryptography-provider-openssl3-prebuilt" }
 cryptography-jdk = { module = "dev.whyoleg.cryptography:cryptography-provider-jdk" }
+slf4j-simple = "org.slf4j:slf4j-simple:2.0.12"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
         // for test (kotlin/jvm)
         jvmTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.slf4j.simple)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add slf4j-simple dependency
- use the logger in JVM test runtime for modules

## Testing
- `./gradlew core:jvmTest stream:jvmTest auth:jvmTest --no-daemon` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_684a986681e0832a8eab105b46d20904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added SLF4J Simple logging support for JVM test environments across multiple modules to enhance test logging output. No changes to application features or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->