### PR TITLE
Convert additional classes to data classes

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetPreferencesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetPreferencesRequest.kt
@@ -4,11 +4,9 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ActorGetPreferencesRequest(
-    auth: AuthProvider
+data class ActorGetPreferencesRequest(
+    override val auth: AuthProvider,
 ) : AuthRequest(auth), MapRequest {
 
-    override fun toMap(): Map<String, Any> {
-        return mapOf()
-    }
+    override fun toMap(): Map<String, Any> = emptyMap()
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetPreferencesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetPreferencesResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsPreferencesUnion
 
 @Serializable
-class ActorGetPreferencesResponse {
-    lateinit var preferences: List<ActorDefsPreferencesUnion>
-}
+data class ActorGetPreferencesResponse(
+    var preferences: List<ActorDefsPreferencesUnion> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetProfileRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetProfileRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ActorGetProfileRequest(
-    auth: AuthProvider
+data class ActorGetProfileRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetProfilesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetProfilesRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ActorGetProfilesRequest(
-    auth: AuthProvider
+data class ActorGetProfilesRequest(
+    override val auth: AuthProvider,
+    var actors: List<String>? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actors: List<String>? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetProfilesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorGetProfilesResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewDetailed
 
 @Serializable
-class ActorGetProfilesResponse {
-    lateinit var profiles: List<ActorDefsProfileViewDetailed>
-}
+data class ActorGetProfilesResponse(
+    var profiles: List<ActorDefsProfileViewDetailed> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsRequest.kt
@@ -4,20 +4,16 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ActorSearchActorsRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest {
-
+data class ActorSearchActorsRequest(
+    override val auth: AuthProvider,
     /** DEPRECATED: use 'q' instead. */
-    var term: String? = null
-
+    var term: String? = null,
     /** Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
-    var q: String? = null
-
+    var q: String? = null,
     /** 1-100 default:25*/
-    var limit: Int? = null
-
-    var cursor: String? = null
+    var limit: Int? = null,
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class ActorSearchActorsResponse {
-    var cursor: String? = null
-    lateinit var actors: List<ActorDefsProfileView>
-}
+data class ActorSearchActorsResponse(
+    var cursor: String? = null,
+    var actors: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsTypeaheadRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsTypeaheadRequest.kt
@@ -4,18 +4,15 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ActorSearchActorsTypeaheadRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest {
-
+data class ActorSearchActorsTypeaheadRequest(
+    override val auth: AuthProvider,
     /** DEPRECATED: use 'q' instead. */
-    var term: String? = null
-
+    var term: String? = null,
     /** Search query prefix; not a full query string. */
-    var q: String? = null
-
+    var q: String? = null,
     /** 1-100 default:10*/
-    var limit: Int? = null
+    var limit: Int? = null,
+) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsTypeaheadResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorSearchActorsTypeaheadResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class ActorSearchActorsTypeaheadResponse {
-    lateinit var actors: List<ActorDefsProfileView>
-}
+data class ActorSearchActorsTypeaheadResponse(
+    var actors: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorUpdateProfileRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/actor/ActorUpdateProfileRequest.kt
@@ -5,8 +5,8 @@ import work.socialhub.kbsky.auth.AuthProvider
 import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
 import work.socialhub.kbsky.model.share.Blob
 
-class ActorUpdateProfileRequest(
-    auth: AuthProvider,
+data class ActorUpdateProfileRequest(
+    override val auth: AuthProvider,
     val displayName: String? = null,
     val description: String? = null,
     val avatar: Blob? = null,

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeleteLikeRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeleteLikeRequest.kt
@@ -8,10 +8,8 @@ import work.socialhub.kbsky.auth.AuthProvider
  * Uri includes the rkey.
  * so, uri or rkey is enough.
  */
-class FeedDeleteLikeRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), RKeyRequest {
-
-    override var uri: String? = null
-    override var rkey: String? = null
-}
+data class FeedDeleteLikeRequest(
+    override val auth: AuthProvider,
+    override var uri: String? = null,
+    override var rkey: String? = null,
+) : AuthRequest(auth), RKeyRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeletePostRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeletePostRequest.kt
@@ -8,10 +8,8 @@ import work.socialhub.kbsky.auth.AuthProvider
  * Uri includes the rkey.
  * so, uri or rkey is enough.
  */
-class FeedDeletePostRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), RKeyRequest {
-
-    override var uri: String? = null
-    override var rkey: String? = null
-}
+data class FeedDeletePostRequest(
+    override val auth: AuthProvider,
+    override var uri: String? = null,
+    override var rkey: String? = null,
+) : AuthRequest(auth), RKeyRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeleteRepostRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeleteRepostRequest.kt
@@ -8,10 +8,8 @@ import work.socialhub.kbsky.auth.AuthProvider
  * Uri includes the rkey.
  * so, uri or rkey is enough.
  */
-class FeedDeleteRepostRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), RKeyRequest {
-
-    override var uri: String? = null
-    override var rkey: String? = null
-}
+data class FeedDeleteRepostRequest(
+    override val auth: AuthProvider,
+    override var uri: String? = null,
+    override var rkey: String? = null,
+) : AuthRequest(auth), RKeyRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorFeedsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorFeedsRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetActorFeedsRequest(
-    auth: AuthProvider
+data class FeedGetActorFeedsRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorFeedsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorFeedsResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsGeneratorView
 
 @Serializable
-class FeedGetActorFeedsResponse {
-    var cursor: String? = null
-    lateinit var feeds: List<FeedDefsGeneratorView>
-}
+data class FeedGetActorFeedsResponse(
+    var cursor: String? = null,
+    var feeds: List<FeedDefsGeneratorView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorLikesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorLikesRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetActorLikesRequest(
-    auth: AuthProvider
+data class FeedGetActorLikesRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorLikesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetActorLikesResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsFeedViewPost
 
 @Serializable
-class FeedGetActorLikesResponse {
-    var cursor: String? = null
-    lateinit var feed: List<FeedDefsFeedViewPost>
-}
+data class FeedGetActorLikesResponse(
+    var cursor: String? = null,
+    var feed: List<FeedDefsFeedViewPost> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
@@ -4,14 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetAuthorFeedRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest {
-
-    lateinit var actor: String
-
-    var limit: Int? = null
-    var cursor: String? = null
+data class FeedGetAuthorFeedRequest(
+    override val auth: AuthProvider,
+    var actor: String = "",
+    var limit: Int? = null,
+    var cursor: String? = null,
 
     enum class Filter(val value: String) {
         PostsWithReplies("posts_with_replies"),

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedRequest.kt
@@ -4,11 +4,17 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
+/**
+ * Request to fetch an author's feed.
+ */
 data class FeedGetAuthorFeedRequest(
     override val auth: AuthProvider,
     var actor: String = "",
     var limit: Int? = null,
     var cursor: String? = null,
+    var filter: Filter? = null,
+    var includePins: Boolean = false,
+) : AuthRequest(auth), MapRequest {
 
     enum class Filter(val value: String) {
         PostsWithReplies("posts_with_replies"),
@@ -18,17 +24,12 @@ data class FeedGetAuthorFeedRequest(
         PostsAndAuthorThreads("posts_and_author_threads")
     }
 
-    var filter: Filter? = null
-
-    var includePins: Boolean = false
-
-    override fun toMap(): Map<String, Any> {
-        return mutableMapOf<String, Any>().also {
+    override fun toMap(): Map<String, Any> =
+        mutableMapOf<String, Any>().also {
             it.addParam("actor", actor)
             it.addParam("limit", limit)
             it.addParam("cursor", cursor)
             it.addParam("filter", filter?.value)
             it.addParam("includePins", includePins)
         }
-    }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetAuthorFeedResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsFeedViewPost
 
 @Serializable
-class FeedGetAuthorFeedResponse {
-    var cursor: String? = null
-    lateinit var feed: List<FeedDefsFeedViewPost>
-}
+data class FeedGetAuthorFeedResponse(
+    var cursor: String? = null,
+    var feed: List<FeedDefsFeedViewPost> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetFeedGeneratorRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest {
-
+data class FeedGetFeedGeneratorRequest(
+    override val auth: AuthProvider,
     /** at-uri  */
-    var feed: String? = null
+    var feed: String? = null,
+) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorResponse.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsGeneratorView
 
 @Serializable
-class FeedGetFeedGeneratorResponse {
-    var view: FeedDefsGeneratorView? = null
-    var online: Boolean? = null
-    var valid: Boolean? = null
-}
+data class FeedGetFeedGeneratorResponse(
+    var view: FeedDefsGeneratorView? = null,
+    var online: Boolean? = null,
+    var valid: Boolean? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorsRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetFeedGeneratorsRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest {
-
+data class FeedGetFeedGeneratorsRequest(
+    override val auth: AuthProvider,
     /** at-uri  */
-    var feeds: List<String>? = null
+    var feeds: List<String>? = null,
+) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedGeneratorsResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsGeneratorView
 
 @Serializable
-class FeedGetFeedGeneratorsResponse {
-    lateinit var feeds: List<FeedDefsGeneratorView>
-}
+data class FeedGetFeedGeneratorsResponse(
+    var feeds: List<FeedDefsGeneratorView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedRequest.kt
@@ -4,14 +4,13 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetFeedRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest {
-
+data class FeedGetFeedRequest(
+    override val auth: AuthProvider,
     /** at-url  */
-    var feed: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
+    var feed: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetFeedResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsFeedViewPost
 
 @Serializable
-class FeedGetFeedResponse {
-    var cursor: String? = null
-    lateinit var feed: List<FeedDefsFeedViewPost>
-}
+data class FeedGetFeedResponse(
+    var cursor: String? = null,
+    var feed: List<FeedDefsFeedViewPost> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetLikesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetLikesRequest.kt
@@ -4,15 +4,13 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetLikesRequest(
-    auth: AuthProvider
+data class FeedGetLikesRequest(
+    override val auth: AuthProvider,
+    var uri: String = "",
+    var cid: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var uri: String
-
-    var cid: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetLikesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetLikesResponse.kt
@@ -4,9 +4,9 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedGetLikesLike
 
 @Serializable
-class FeedGetLikesResponse {
-    lateinit var uri: String
-    var cid: String? = null
-    var cursor: String? = null
-    lateinit var likes: List<FeedGetLikesLike>
-}
+data class FeedGetLikesResponse(
+    var uri: String = "",
+    var cid: String? = null,
+    var cursor: String? = null,
+    var likes: List<FeedGetLikesLike> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetListFeedRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetListFeedRequest.kt
@@ -4,14 +4,13 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetListFeedRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest {
-
+data class FeedGetListFeedRequest(
+    override val auth: AuthProvider,
     /** at-url  */
-    var list: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
+    var list: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetListFeedResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetListFeedResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsFeedViewPost
 
 @Serializable
-class FeedGetListFeedResponse {
-    var cursor: String? = null
-    lateinit var feed: List<FeedDefsFeedViewPost>
-}
+data class FeedGetListFeedResponse(
+    var cursor: String? = null,
+    var feed: List<FeedDefsFeedViewPost> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostThreadRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostThreadRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetPostThreadRequest(
-    auth: AuthProvider
+data class FeedGetPostThreadRequest(
+    override val auth: AuthProvider,
+    var uri: String = "",
+    var depth: Int? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var uri: String
-    var depth: Int? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostThreadResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostThreadResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsThreadUnion
 
 @Serializable
-class FeedGetPostThreadResponse {
-    lateinit var thread: FeedDefsThreadUnion
-}
+data class FeedGetPostThreadResponse(
+    lateinit var thread: FeedDefsThreadUnion,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostThreadResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostThreadResponse.kt
@@ -3,7 +3,10 @@ package work.socialhub.kbsky.api.entity.app.bsky.feed
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsThreadUnion
 
+/**
+ * Response for a post thread request.
+ */
 @Serializable
 data class FeedGetPostThreadResponse(
-    lateinit var thread: FeedDefsThreadUnion,
+    var thread: FeedDefsThreadUnion? = null,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostsRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetPostsRequest(
-    auth: AuthProvider
+data class FeedGetPostsRequest(
+    override val auth: AuthProvider,
+    var uris: List<String>? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var uris: List<String>? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetPostsResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
 
 @Serializable
-class FeedGetPostsResponse {
-    lateinit var posts: List<FeedDefsPostView>
-}
+data class FeedGetPostsResponse(
+    var posts: List<FeedDefsPostView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesRequest.kt
@@ -4,15 +4,13 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetQuotesRequest(
-    auth: AuthProvider
+data class FeedGetQuotesRequest(
+    override val auth: AuthProvider,
+    var uri: String = "",
+    var cid: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var uri: String
-
-    var cid: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetQuotesResponse.kt
@@ -4,13 +4,9 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
 
 @Serializable
-class FeedGetQuotesResponse {
-
-    lateinit var uri: String
-
-    var cid: String? = null
-
-    var cursor: String? = null
-
-    lateinit var posts: List<FeedDefsPostView>
-}
+data class FeedGetQuotesResponse(
+    var uri: String = "",
+    var cid: String? = null,
+    var cursor: String? = null,
+    var posts: List<FeedDefsPostView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetRepostedByRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetRepostedByRequest.kt
@@ -4,15 +4,13 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetRepostedByRequest(
-    auth: AuthProvider
+data class FeedGetRepostedByRequest(
+    override val auth: AuthProvider,
+    var uri: String = "",
+    var cid: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var uri: String
-
-    var cid: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetRepostedByResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetRepostedByResponse.kt
@@ -4,9 +4,9 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class FeedGetRepostedByResponse {
-    lateinit var uri: String
-    var cid: String? = null
-    var cursor: String? = null
-    lateinit var repostedBy: List<ActorDefsProfileView>
-}
+data class FeedGetRepostedByResponse(
+    var uri: String = "",
+    var cid: String? = null,
+    var cursor: String? = null,
+    var repostedBy: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetTimelineRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetTimelineRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedGetTimelineRequest(
-    auth: AuthProvider
+data class FeedGetTimelineRequest(
+    override val auth: AuthProvider,
+    var algorithm: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var algorithm: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetTimelineResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetTimelineResponse.kt
@@ -3,7 +3,7 @@ package work.socialhub.kbsky.api.entity.app.bsky.feed
 import kotlinx.serialization.Serializable
 
 @Serializable
-class FeedGetTimelineResponse {
-    var cursor: String? = null
-    lateinit var feed: List<work.socialhub.kbsky.model.app.bsky.feed.FeedDefsFeedViewPost>
-}
+data class FeedGetTimelineResponse(
+    var cursor: String? = null,
+    var feed: List<work.socialhub.kbsky.model.app.bsky.feed.FeedDefsFeedViewPost> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedLikeRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedLikeRequest.kt
@@ -8,12 +8,11 @@ import work.socialhub.kbsky.internal.share._InternalUtility.toJson
 import work.socialhub.kbsky.model.app.bsky.feed.FeedLike
 import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
 
-class FeedLikeRequest(
-    auth: AuthProvider
+data class FeedLikeRequest(
+    override val auth: AuthProvider,
+    var subject: RepoStrongRef? = null,
+    override var createdAt: String? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    var subject: RepoStrongRef? = null
-    override var createdAt: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedPostRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedPostRequest.kt
@@ -11,19 +11,17 @@ import work.socialhub.kbsky.model.app.bsky.feed.FeedPostReplyRef
 import work.socialhub.kbsky.model.app.bsky.richtext.RichtextFacet
 import work.socialhub.kbsky.model.com.atproto.label.LabelDefsSelfLabels
 
-class FeedPostRequest(
-    auth: AuthProvider
+data class FeedPostRequest(
+    override val auth: AuthProvider,
+    var text: String = "",
+    var langs: List<String>? = null,
+    var labels: LabelDefsSelfLabels? = null,
+    var facets: List<RichtextFacet>? = null,
+    var reply: FeedPostReplyRef? = null,
+    var embed: EmbedUnion? = null,
+    override var createdAt: String? = null,
+    var via: String? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    lateinit var text: String
-
-    var langs: List<String>? = null
-    var labels: LabelDefsSelfLabels? = null
-    var facets: List<RichtextFacet>? = null
-    var reply: FeedPostReplyRef? = null
-    var embed: EmbedUnion? = null
-    override var createdAt: String? = null
-    var via: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedPostgateRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedPostgateRequest.kt
@@ -8,19 +8,15 @@ import work.socialhub.kbsky.internal.share._InternalUtility.toJson
 import work.socialhub.kbsky.model.app.bsky.feed.FeedPostgate
 import work.socialhub.kbsky.model.app.bsky.feed.FeedPostgateEmbeddingRulesUnion
 
-class FeedPostgateRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    override var createdAt: String? = null
-
+data class FeedPostgateRequest(
+    override val auth: AuthProvider,
+    override var createdAt: String? = null,
     // at-uri
-    lateinit var post: String
-
+    var post: String = "",
     // List of AT-URIs embedding this post that the author has detached from.
-    var detachedEmbeddingUris: List<String>? = null
-
-    var embeddingRules: List<FeedPostgateEmbeddingRulesUnion>? = null
+    var detachedEmbeddingUris: List<String>? = null,
+    var embeddingRules: List<FeedPostgateEmbeddingRulesUnion>? = null,
+) : AuthRequest(auth), MapRequest, RecordRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedRepostRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedRepostRequest.kt
@@ -8,12 +8,11 @@ import work.socialhub.kbsky.internal.share._InternalUtility.toJson
 import work.socialhub.kbsky.model.app.bsky.feed.FeedRepost
 import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
 
-class FeedRepostRequest(
-    auth: AuthProvider
+data class FeedRepostRequest(
+    override val auth: AuthProvider,
+    var subject: RepoStrongRef? = null,
+    override var createdAt: String? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    var subject: RepoStrongRef? = null
-    override var createdAt: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsRequest.kt
@@ -4,17 +4,15 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class FeedSearchPostsRequest(
-    auth: AuthProvider,
+data class FeedSearchPostsRequest(
+    override val auth: AuthProvider,
     /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
     var q: String,
-) : AuthRequest(auth), MapRequest {
-
     // [1-100] default: 25
-    var limit: Int? = null
-
+    var limit: Int? = null,
     /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
-    var cursor: String? = null
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsResponse.kt
@@ -4,10 +4,10 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
 
 @Serializable
-class FeedSearchPostsResponse {
-    var cursor: String? = null
+data class FeedSearchPostsResponse(
+    var cursor: String? = null,
 
     /** Count of search hits. Optional, may be rounded/truncated, and may not be possible to paginate through all hits. */
-    var hitsTotal: Int? = null
-    lateinit var posts: List<FeedDefsPostView>
-}
+    var hitsTotal: Int? = null,
+    var posts: List<FeedDefsPostView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedThreadgateRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedThreadgateRequest.kt
@@ -8,14 +8,12 @@ import work.socialhub.kbsky.internal.share._InternalUtility.toJson
 import work.socialhub.kbsky.model.app.bsky.feed.FeedThreadgate
 import work.socialhub.kbsky.model.app.bsky.feed.FeedThreadgateAllowUnion
 
-class FeedThreadgateRequest(
-    auth: AuthProvider
+data class FeedThreadgateRequest(
+    override val auth: AuthProvider,
+    override var createdAt: String? = null,
+    var post: String = "",
+    var allow: List<FeedThreadgateAllowUnion>? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    override var createdAt: String? = null
-    lateinit var post: String
-
-    var allow: List<FeedThreadgateAllowUnion>? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphAddUserToListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphAddUserToListRequest.kt
@@ -10,7 +10,7 @@ data class GraphAddUserToListRequest(
     override val auth: AuthProvider,
     var userDid: String? = null,
     var listUri: String? = null,
-    override var createdAt: String? = createdAt(),
+    override var createdAt: String? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
 
     override fun toMap(): Map<String, Any> {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphAddUserToListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphAddUserToListRequest.kt
@@ -6,13 +6,12 @@ import work.socialhub.kbsky.api.entity.share.RecordRequest
 import work.socialhub.kbsky.auth.AuthProvider
 import work.socialhub.kbsky.model.app.bsky.graph.GraphListItem
 
-class GraphAddUserToListRequest(
-    auth: AuthProvider
+data class GraphAddUserToListRequest(
+    override val auth: AuthProvider,
+    var userDid: String? = null,
+    var listUri: String? = null,
+    override var createdAt: String? = createdAt(),
 ) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    var userDid: String? = null
-    var listUri: String? = null
-    override var createdAt: String? = createdAt()
 
     override fun toMap(): Map<String, Any> {
         return emptyMap()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphBlockRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphBlockRequest.kt
@@ -6,12 +6,11 @@ import work.socialhub.kbsky.api.entity.share.RecordRequest
 import work.socialhub.kbsky.auth.AuthProvider
 import work.socialhub.kbsky.model.app.bsky.graph.GraphBlock
 
-class GraphBlockRequest(
-    auth: AuthProvider
+data class GraphBlockRequest(
+    override val auth: AuthProvider,
+    var subject: String? = null,
+    override var createdAt: String? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    var subject: String? = null
-    override var createdAt: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphCreateListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphCreateListRequest.kt
@@ -9,8 +9,8 @@ import work.socialhub.kbsky.model.app.bsky.richtext.RichtextFacet
 import work.socialhub.kbsky.model.com.atproto.label.LabelDefsSelfLabels
 import work.socialhub.kbsky.model.share.Blob
 
-class GraphCreateListRequest(
-    auth: AuthProvider,
+data class GraphCreateListRequest(
+    override val auth: AuthProvider,
     private val purpose: String = "app.bsky.graph.defs#curatelist",
     private val name: String,
     private val description: String?,

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphDeleteBlockRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphDeleteBlockRequest.kt
@@ -4,10 +4,8 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.RKeyRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphDeleteBlockRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), RKeyRequest {
-
-    override var uri: String? = null
-    override var rkey: String? = null
-}
+data class GraphDeleteBlockRequest(
+    override val auth: AuthProvider,
+    override var uri: String? = null,
+    override var rkey: String? = null,
+) : AuthRequest(auth), RKeyRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphDeleteFollowRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphDeleteFollowRequest.kt
@@ -4,10 +4,8 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.RKeyRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphDeleteFollowRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), RKeyRequest {
-
-    override var uri: String? = null
-    override var rkey: String? = null
-}
+data class GraphDeleteFollowRequest(
+    override val auth: AuthProvider,
+    override var uri: String? = null,
+    override var rkey: String? = null,
+) : AuthRequest(auth), RKeyRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphDeleteListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphDeleteListRequest.kt
@@ -3,7 +3,7 @@ package work.socialhub.kbsky.api.entity.app.bsky.graph
 import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphDeleteListRequest(
-    auth: AuthProvider,
+data class GraphDeleteListRequest(
+    override val auth: AuthProvider,
     val listUri: String,
 ) : AuthRequest(auth)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphEditListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphEditListRequest.kt
@@ -6,8 +6,8 @@ import work.socialhub.kbsky.model.app.bsky.richtext.RichtextFacet
 import work.socialhub.kbsky.model.com.atproto.label.LabelDefsSelfLabels
 import work.socialhub.kbsky.model.share.Blob
 
-class GraphEditListRequest(
-    auth: AuthProvider,
+data class GraphEditListRequest(
+    override val auth: AuthProvider,
     val listUri: String,
     val name: String,
     val description: String?,

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphEditListResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphEditListResponse.kt
@@ -4,4 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoPutRecordResponse
 
 @Serializable
-class GraphEditListResponse : RepoPutRecordResponse()
+data class GraphEditListResponse(
+    val dummy: Unit = Unit,
+) : RepoPutRecordResponse()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphFollowRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphFollowRequest.kt
@@ -6,12 +6,11 @@ import work.socialhub.kbsky.api.entity.share.RecordRequest
 import work.socialhub.kbsky.auth.AuthProvider
 import work.socialhub.kbsky.model.app.bsky.graph.GraphFollow
 
-class GraphFollowRequest(
-    auth: AuthProvider
+data class GraphFollowRequest(
+    override val auth: AuthProvider,
+    var subject: String? = null,
+    override var createdAt: String? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
-
-    var subject: String? = null
-    override var createdAt: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphFollowResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphFollowResponse.kt
@@ -4,4 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoCreateRecordResponse
 
 @Serializable
-class GraphFollowResponse : RepoCreateRecordResponse()
+data class GraphFollowResponse(
+    val dummy: Unit = Unit,
+) : RepoCreateRecordResponse()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetBlocksRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetBlocksRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetBlocksRequest(
-    auth: AuthProvider
+data class GraphGetBlocksRequest(
+    override val auth: AuthProvider,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetBlocksResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetBlocksResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class GraphGetBlocksResponse {
-    var cursor: String? = null
-    lateinit var blocks: List<ActorDefsProfileView>
-}
+data class GraphGetBlocksResponse(
+    var cursor: String? = null,
+    var blocks: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowersRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetFollowersRequest(
-    auth: AuthProvider
+data class GraphGetFollowersRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowersResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowersResponse.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class GraphGetFollowersResponse {
-    var cursor: String? = null
-    lateinit var subject: ActorDefsProfileView
-    lateinit var followers: List<ActorDefsProfileView>
-}
+data class GraphGetFollowersResponse(
+    var cursor: String? = null,
+    var subject: ActorDefsProfileView = ActorDefsProfileView(),
+    var followers: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowsRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetFollowsRequest(
-    auth: AuthProvider
+data class GraphGetFollowsRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetFollowsResponse.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class GraphGetFollowsResponse {
-    var cursor: String? = null
-    lateinit var subject: ActorDefsProfileView
-    lateinit var follows: List<ActorDefsProfileView>
-}
+data class GraphGetFollowsResponse(
+    var cursor: String? = null,
+    var subject: ActorDefsProfileView = ActorDefsProfileView(),
+    var follows: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetKnownFollowersRequest(
-    auth: AuthProvider
+data class GraphGetKnownFollowersRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetKnownFollowersResponse.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class GraphGetKnownFollowersResponse {
-    var cursor: String? = null
-    lateinit var subject: ActorDefsProfileView
-    lateinit var followers: List<ActorDefsProfileView>
-}
+data class GraphGetKnownFollowersResponse(
+    var cursor: String? = null,
+    var subject: ActorDefsProfileView = ActorDefsProfileView(),
+    var followers: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetListRequest(
-    auth: AuthProvider
+data class GraphGetListRequest(
+    override val auth: AuthProvider,
+    var list: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var list: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListResponse.kt
@@ -5,8 +5,8 @@ import work.socialhub.kbsky.model.app.bsky.graph.GraphDefsListItemView
 import work.socialhub.kbsky.model.app.bsky.graph.GraphDefsListView
 
 @Serializable
-class GraphGetListResponse {
-    var cursor: String? = null
-    lateinit var list: GraphDefsListView
-    lateinit var items: List<GraphDefsListItemView>
-}
+data class GraphGetListResponse(
+    var cursor: String? = null,
+    var list: GraphDefsListView = GraphDefsListView(),
+    var items: List<GraphDefsListItemView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListsRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetListsRequest(
-    auth: AuthProvider
+data class GraphGetListsRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetListsResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.graph.GraphDefsListView
 
 @Serializable
-class GraphGetListsResponse {
-    var cursor: String? = null
-    lateinit var lists: List<GraphDefsListView>
-}
+data class GraphGetListsResponse(
+    var cursor: String? = null,
+    var lists: List<GraphDefsListView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetMutesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetMutesRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetMutesRequest(
-    auth: AuthProvider
+data class GraphGetMutesRequest(
+    override val auth: AuthProvider,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetMutesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetMutesResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class GraphGetMutesResponse {
-    var cursor: String? = null
-    lateinit var mutes: List<ActorDefsProfileView>
-}
+data class GraphGetMutesResponse(
+    var cursor: String? = null,
+    var mutes: List<ActorDefsProfileView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPackRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetStarterPackRequest(
-    auth: AuthProvider
+data class GraphGetStarterPackRequest(
+    override val auth: AuthProvider,
+    var starterPack: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var starterPack: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphGetStarterPacksRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphGetStarterPacksRequest(
-    auth: AuthProvider
+data class GraphGetStarterPacksRequest(
+    override val auth: AuthProvider,
+    var uris: List<String>? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var uris: List<String>? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphMuteActorRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphMuteActorRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphMuteActorRequest(
-    auth: AuthProvider
+data class GraphMuteActorRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphRemoveUserFromListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphRemoveUserFromListRequest.kt
@@ -4,10 +4,8 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.RKeyRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphRemoveUserFromListRequest(
-    auth: AuthProvider
-) : AuthRequest(auth), RKeyRequest {
-
-    override var uri: String? = null
-    override var rkey: String? = null
-}
+data class GraphRemoveUserFromListRequest(
+    override val auth: AuthProvider,
+    override var uri: String? = null,
+    override var rkey: String? = null,
+) : AuthRequest(auth), RKeyRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphUnmuteActorRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphUnmuteActorRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class GraphUnmuteActorRequest(
-    auth: AuthProvider
+data class GraphUnmuteActorRequest(
+    override val auth: AuthProvider,
+    var actor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var actor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/labeler/LabelerGetServicesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/labeler/LabelerGetServicesRequest.kt
@@ -3,10 +3,8 @@ package work.socialhub.kbsky.api.entity.app.bsky.labeler
 import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class LabelerGetServicesRequest(
-    auth: AuthProvider
-) : AuthRequest(auth) {
-
-    lateinit var dids: List<String>
-    var detailed: Boolean? = null
-}
+data class LabelerGetServicesRequest(
+    override val auth: AuthProvider,
+    var dids: List<String> = emptyList(),
+    var detailed: Boolean? = null,
+) : AuthRequest(auth)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/labeler/LabelerGetServicesResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/labeler/LabelerGetServicesResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.labeler.LabelerViewUnion
 
 @Serializable
-class LabelerGetServicesResponse {
-    lateinit var views: List<LabelerViewUnion>
-}
+data class LabelerGetServicesResponse(
+    var views: List<LabelerViewUnion> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationGetUnreadCountRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationGetUnreadCountRequest.kt
@@ -3,6 +3,6 @@ package work.socialhub.kbsky.api.entity.app.bsky.notification
 import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class NotificationGetUnreadCountRequest(
-    auth: AuthProvider
+data class NotificationGetUnreadCountRequest(
+    override val auth: AuthProvider,
 ) : AuthRequest(auth)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationGetUnreadCountResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationGetUnreadCountResponse.kt
@@ -3,6 +3,6 @@ package work.socialhub.kbsky.api.entity.app.bsky.notification
 import kotlinx.serialization.Serializable
 
 @Serializable
-class NotificationGetUnreadCountResponse {
-    var count: Int = -1
-}
+data class NotificationGetUnreadCountResponse(
+    var count: Int = -1,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationListNotificationsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationListNotificationsRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class NotificationListNotificationsRequest(
-    auth: AuthProvider
+data class NotificationListNotificationsRequest(
+    override val auth: AuthProvider,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationListNotificationsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationListNotificationsResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.notification.NotificationListNotificationsNotification
 
 @Serializable
-class NotificationListNotificationsResponse {
-    var cursor: String? = null
-    lateinit var notifications: List<NotificationListNotificationsNotification>
-}
+data class NotificationListNotificationsResponse(
+    var cursor: String? = null,
+    var notifications: List<NotificationListNotificationsNotification> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationUpdateSeenRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/notification/NotificationUpdateSeenRequest.kt
@@ -6,11 +6,10 @@ import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 import work.socialhub.kbsky.internal.share._InternalUtility
 
-class NotificationUpdateSeenRequest(
-    auth: AuthProvider
+data class NotificationUpdateSeenRequest(
+    override val auth: AuthProvider,
+    var seenAt: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var seenAt: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class UnspeccedGetPopularRequest(
-    auth: AuthProvider
+data class UnspeccedGetPopularRequest(
+    override val auth: AuthProvider,
+    var includeNsfw: Boolean? = null,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var includeNsfw: Boolean? = null
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsFeedViewPost
 
 @Serializable
-class UnspeccedGetPopularResponse {
-    var cursor: String? = null
-    lateinit var feed: List<FeedDefsFeedViewPost>
-}
+data class UnspeccedGetPopularResponse(
+    var cursor: String? = null,
+    var feed: List<FeedDefsFeedViewPost> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedSearchFeedsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedSearchFeedsRequest.kt
@@ -2,8 +2,9 @@ package work.socialhub.kbsky.api.entity.app.bsky.unspecced
 
 import work.socialhub.kbsky.api.entity.share.MapRequest
 
-class UnspeccedSearchFeedsRequest : MapRequest {
-    var q: String? = null
+data class UnspeccedSearchFeedsRequest(
+    var q: String? = null,
+) : MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedSearchFeedsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedSearchFeedsResponse.kt
@@ -5,9 +5,9 @@ import work.socialhub.kbsky.model.app.bsky.undoc.UndocSearchFeedsPost
 import work.socialhub.kbsky.model.app.bsky.undoc.UndocSearchFeedsUser
 
 @Serializable
-class UnspeccedSearchFeedsResponse {
-    var cid: String? = null
-    var tid: String? = null
-    var user: UndocSearchFeedsUser? = null
-    var post: UndocSearchFeedsPost? = null
-}
+data class UnspeccedSearchFeedsResponse(
+    var cid: String? = null,
+    var tid: String? = null,
+    var user: UndocSearchFeedsUser? = null,
+    var post: UndocSearchFeedsPost? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetJobStatusRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetJobStatusRequest.kt
@@ -4,9 +4,9 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class VideoGetJobStatusRequest(
-    auth: AuthProvider,
-    val jobId: String
+data class VideoGetJobStatusRequest(
+    override val auth: AuthProvider,
+    val jobId: String,
 ) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetJobStatusResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetJobStatusResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.video.JobStatus
 
 @Serializable
-class VideoGetJobStatusResponse {
-    lateinit var jobStatus: JobStatus
-}
+data class VideoGetJobStatusResponse(
+    lateinit var jobStatus: JobStatus,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetJobStatusResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetJobStatusResponse.kt
@@ -3,7 +3,10 @@ package work.socialhub.kbsky.api.entity.app.bsky.video
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.video.JobStatus
 
+/**
+ * Response for retrieving video job status.
+ */
 @Serializable
 data class VideoGetJobStatusResponse(
-    lateinit var jobStatus: JobStatus,
+    var jobStatus: JobStatus? = null,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetUploadLimitsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoGetUploadLimitsRequest.kt
@@ -3,6 +3,6 @@ package work.socialhub.kbsky.api.entity.app.bsky.video
 import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class VideoGetUploadLimitsRequest(
-    auth: AuthProvider,
+data class VideoGetUploadLimitsRequest(
+    override val auth: AuthProvider,
 ) : AuthRequest(auth)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoUploadVideoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/video/VideoUploadVideoRequest.kt
@@ -3,8 +3,8 @@ package work.socialhub.kbsky.api.entity.app.bsky.video
 import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class VideoUploadVideoRequest(
-    auth: AuthProvider,
+data class VideoUploadVideoRequest(
+    override val auth: AuthProvider,
     var bytes: ByteArray,
     var name: String = "data.mp4",
     var contentType: String = "video/mp4",

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoDeleteMessageForSelfRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoDeleteMessageForSelfRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoDeleteMessageForSelfRequest(
-    auth: AuthProvider
+data class ConvoDeleteMessageForSelfRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var messageId: String = "",
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
-    lateinit var messageId: String
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoForMembersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoForMembersRequest.kt
@@ -4,12 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoGetConvoForMembersRequest(
-    auth: AuthProvider
+data class ConvoGetConvoForMembersRequest(
+    override val auth: AuthProvider,
+    var members: List<String> = emptyList(),
 ) : AuthRequest(auth), MapRequest {
-
-    // did
-    lateinit var members: List<String>
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoGetConvoRequest(
-    auth: AuthProvider
+data class ConvoGetConvoRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetListConvosRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetListConvosRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoGetListConvosRequest(
-    auth: AuthProvider
+data class ConvoGetListConvosRequest(
+    override val auth: AuthProvider,
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetLogRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetLogRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoGetLogRequest(
-    auth: AuthProvider
+data class ConvoGetLogRequest(
+    override val auth: AuthProvider,
+    var cursor: String = "",
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var cursor: String
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetMessagesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetMessagesRequest.kt
@@ -4,13 +4,12 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoGetMessagesRequest(
-    auth: AuthProvider
+data class ConvoGetMessagesRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var limit: Int? = null,
+    var cursor: String? = null,
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
-    var limit: Int? = null
-    var cursor: String? = null
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoLeaveConvoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoLeaveConvoRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoLeaveConvoRequest(
-    auth: AuthProvider
+data class ConvoLeaveConvoRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoMuteConvoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoMuteConvoRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoMuteConvoRequest(
-    auth: AuthProvider
+data class ConvoMuteConvoRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoSendMessageRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoSendMessageRequest.kt
@@ -5,12 +5,11 @@ import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageInput
 
-class ConvoSendMessageRequest(
-    auth: AuthProvider
+data class ConvoSendMessageRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    lateinit var message: ConvoDefsMessageInput,
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
-    lateinit var message: ConvoDefsMessageInput
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoSendMessageRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoSendMessageRequest.kt
@@ -8,7 +8,7 @@ import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageInput
 data class ConvoSendMessageRequest(
     override val auth: AuthProvider,
     var convoId: String = "",
-    lateinit var message: ConvoDefsMessageInput,
+    var message: ConvoDefsMessageInput? = null,
 ) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUnmuteConvoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUnmuteConvoRequest.kt
@@ -4,11 +4,10 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoUnmuteConvoRequest(
-    auth: AuthProvider
+data class ConvoUnmuteConvoRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUpdateReadRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUpdateReadRequest.kt
@@ -4,12 +4,11 @@ import work.socialhub.kbsky.api.entity.share.AuthRequest
 import work.socialhub.kbsky.api.entity.share.MapRequest
 import work.socialhub.kbsky.auth.AuthProvider
 
-class ConvoUpdateReadRequest(
-    auth: AuthProvider
+data class ConvoUpdateReadRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var messageId: String = "",
 ) : AuthRequest(auth), MapRequest {
-
-    lateinit var convoId: String
-    lateinit var messageId: String
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/identity/IdentityResolveHandleResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/identity/IdentityResolveHandleResponse.kt
@@ -6,6 +6,6 @@ import kotlinx.serialization.Serializable
  * https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/identity/resolveHandle.json
  */
 @Serializable
-class IdentityResolveHandleResponse {
-    lateinit var did: String
-}
+data class IdentityResolveHandleResponse(
+    var did: String = "",
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/repo/RepoGetRecordResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/repo/RepoGetRecordResponse.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-class RepoGetRecordResponse {
-    lateinit var uri: String
-    var cid: String? = null
-    lateinit var value: RecordUnion
-}
+data class RepoGetRecordResponse(
+    var uri: String = "",
+    var cid: String? = null,
+    var value: RecordUnion,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/repo/RepoListRecordsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/repo/RepoListRecordsResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.repo.RepoListRecordsRecord
 
 @Serializable
-class RepoListRecordsResponse {
-    var cursor: String? = null
-    lateinit var records: List<RepoListRecordsRecord>
-}
+data class RepoListRecordsResponse(
+    var cursor: String? = null,
+    var records: List<RepoListRecordsRecord> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/repo/RepoUploadBlobResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/repo/RepoUploadBlobResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.share.Blob
 
 @Serializable
-class RepoUploadBlobResponse {
-    lateinit var blob: Blob
-}
+data class RepoUploadBlobResponse(
+    var blob: Blob = Blob(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerCreateSessionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerCreateSessionResponse.kt
@@ -4,15 +4,15 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.server.DidDocUnion
 
 @Serializable
-class ServerCreateSessionResponse {
-    lateinit var accessJwt: String
-    lateinit var refreshJwt: String
-    lateinit var handle: String
-    lateinit var did: String
+data class ServerCreateSessionResponse(
+    var accessJwt: String = "",
+    var refreshJwt: String = "",
+    var handle: String = "",
+    var did: String = "",
 
-    var email: String? = null
-    var emailConfirmed: Boolean? = null
-    var emailAuthFactor: Boolean? = null
-    var didDoc: DidDocUnion? = null
-    var active: Boolean? = null
-}
+    var email: String? = null,
+    var emailConfirmed: Boolean? = null,
+    var emailAuthFactor: Boolean? = null,
+    var didDoc: DidDocUnion? = null,
+    var active: Boolean? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerGetServiceAuthResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerGetServiceAuthResponse.kt
@@ -3,6 +3,6 @@ package work.socialhub.kbsky.api.entity.com.atproto.server
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ServerGetServiceAuthResponse {
-    lateinit var token: String
-}
+data class ServerGetServiceAuthResponse(
+    var token: String = "",
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerGetSessionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerGetSessionResponse.kt
@@ -4,13 +4,12 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.server.DidDocUnion
 
 @Serializable
-class ServerGetSessionResponse {
-    lateinit var handle: String
-    lateinit var did: String
-
-    var email: String? = null
-    var emailConfirmed: Boolean? = null
-    var emailAuthFactor: Boolean? = null
-    var didDoc: DidDocUnion? = null
-    var active: Boolean? = null
-}
+data class ServerGetSessionResponse(
+    var handle: String = "",
+    var did: String = "",
+    var email: String? = null,
+    var emailConfirmed: Boolean? = null,
+    var emailAuthFactor: Boolean? = null,
+    var didDoc: DidDocUnion? = null,
+    var active: Boolean? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerRefreshSessionResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/server/ServerRefreshSessionResponse.kt
@@ -4,12 +4,11 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.server.DidDocUnion
 
 @Serializable
-class ServerRefreshSessionResponse {
-    lateinit var accessJwt: String
-    lateinit var refreshJwt: String
-    lateinit var handle: String
-    lateinit var did: String
-
-    var didDoc: DidDocUnion? = null
-    var active: Boolean? = null
-}
+data class ServerRefreshSessionResponse(
+    var accessJwt: String = "",
+    var refreshJwt: String = "",
+    var handle: String = "",
+    var did: String = "",
+    var didDoc: DidDocUnion? = null,
+    var active: Boolean? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/Response.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/share/Response.kt
@@ -3,7 +3,7 @@ package work.socialhub.kbsky.api.entity.share
 /**
  * @author uakihir0
  */
-class Response<T>(
+data class Response<T>(
     val data: T,
     val json: String,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsAdultContentPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsAdultContentPref.kt
@@ -5,14 +5,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsAdultContentPref : ActorDefsPreferencesUnion() {
+data class ActorDefsAdultContentPref(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var enabled: Boolean = false,
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#adultContentPref"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var enabled: Boolean = false
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, false)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsContentLabelPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsContentLabelPref.kt
@@ -5,17 +5,18 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsContentLabelPref : ActorDefsPreferencesUnion() {
+data class ActorDefsContentLabelPref(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var label: String = "",
+    /** ["show", "warn", "hide"] */
+    var visibility: String = "",
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#contentLabelPref"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var label: String
-
-    /** ["show", "warn", "hide"] */
-    lateinit var visibility: String
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, "", "")
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsFeedViewPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsFeedViewPref.kt
@@ -5,30 +5,27 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsFeedViewPref : ActorDefsPreferencesUnion() {
+data class ActorDefsFeedViewPref(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    /** The URI of the feed, or an identifier which describes the feed. */
+    var feed: String = "",
+    /** Hide replies in the feed. */
+    var hideReplies: Boolean? = null,
+    /** Hide replies in the feed if they are not by followed users. */
+    var hideRepliesByUnfollowed: Boolean? = null,
+    /** Hide replies in the feed if they do not have this number of likes. */
+    var hideRepliesByLikeCount: Int? = null,
+    /**　Hide reposts in the feed. */
+    var hideReposts: Boolean? = null,
+    /** Hide quote posts in the feed. */
+    var hideQuotePosts: Boolean? = null,
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#feedViewPref"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    /** The URI of the feed, or an identifier which describes the feed. */
-    lateinit var feed: String
-
-    /** Hide replies in the feed. */
-    var hideReplies: Boolean? = null
-
-    /** Hide replies in the feed if they are not by followed users. */
-    var hideRepliesByUnfollowed: Boolean? = null
-
-    /** Hide replies in the feed if they do not have this number of likes. */
-    var hideRepliesByLikeCount: Int? = null
-
-    /**　Hide reposts in the feed. */
-    var hideReposts: Boolean? = null
-
-    /** Hide quote posts in the feed. */
-    var hideQuotePosts: Boolean? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, "", null, null, null, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsKnownFollowers.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsKnownFollowers.kt
@@ -3,10 +3,7 @@ package work.socialhub.kbsky.model.app.bsky.actor
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ActorDefsKnownFollowers {
-
-    val count: Int = 0
-
-    lateinit var followers: List<ActorDefsProfileViewBasic>
-
-}
+data class ActorDefsKnownFollowers(
+    val count: Int = 0,
+    var followers: List<ActorDefsProfileViewBasic> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelersPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsLabelersPref.kt
@@ -5,15 +5,17 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsLabelersPref : ActorDefsPreferencesUnion() {
+data class ActorDefsLabelersPref(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    @SerialName("labelers")
+    var labelers: List<ActorDefsLabelerPrefItem>? = null,
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#labelersPref"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    @SerialName("labelers")
-    var labelers: List<ActorDefsLabelerPrefItem>? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPersonalDetailsPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPersonalDetailsPref.kt
@@ -5,15 +5,17 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsPersonalDetailsPref : ActorDefsPreferencesUnion() {
+data class ActorDefsPersonalDetailsPref(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    /** The birth date of account owner. */
+    var birthDate: String? = null,
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#personalDetailsPref"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    /** The birth date of account owner. */
-    var birthDate: String? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPreferences.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsPreferences.kt
@@ -3,6 +3,6 @@ package work.socialhub.kbsky.model.app.bsky.actor
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ActorDefsPreferences {
-    val items: List<ActorDefsPreferencesUnion>? = null
-}
+data class ActorDefsPreferences(
+    val items: List<ActorDefsPreferencesUnion>? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileAssociated.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileAssociated.kt
@@ -3,10 +3,9 @@ package work.socialhub.kbsky.model.app.bsky.actor
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ActorDefsProfileAssociated {
-
-    var lists: Int? = null
-    var feedgens: Int? = null
-    var labeler: Boolean? = null
-    var chat: ActorDefsProfileAssociatedChat? = null
-}
+data class ActorDefsProfileAssociated(
+    var lists: Int? = null,
+    var feedgens: Int? = null,
+    var labeler: Boolean? = null,
+    var chat: ActorDefsProfileAssociatedChat? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileAssociatedChat.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileAssociatedChat.kt
@@ -3,9 +3,8 @@ package work.socialhub.kbsky.model.app.bsky.actor
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ActorDefsProfileAssociatedChat {
-
+data class ActorDefsProfileAssociatedChat(
     // "knownValues": ["all", "none", "following"]
     // when nothing is set, it is assumed to be "following"
-    lateinit var allowIncoming: String
-}
+    var allowIncoming: String = "",
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileView.kt
@@ -4,18 +4,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
 
 @Serializable
-class ActorDefsProfileView {
-
-    lateinit var did: String
-    lateinit var handle: String
-
-    var displayName: String? = null
-    var description: String? = null
-    var avatar: String? = null
-    var associated: ActorDefsProfileAssociated? = null
-    var indexedAt: String? = null
-    var createdAt: String? = null
-    var viewer: ActorDefsViewerState? = null
-    var labels: List<LabelDefsLabel>? = null
-    var verification: ActorDefsVerificationState? = null
-}
+data class ActorDefsProfileView(
+    var did: String = "",
+    var handle: String = "",
+    var displayName: String? = null,
+    var description: String? = null,
+    var avatar: String? = null,
+    var associated: ActorDefsProfileAssociated? = null,
+    var indexedAt: String? = null,
+    var createdAt: String? = null,
+    var viewer: ActorDefsViewerState? = null,
+    var labels: List<LabelDefsLabel>? = null,
+    var verification: ActorDefsVerificationState? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewBasic.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsProfileViewBasic.kt
@@ -7,17 +7,15 @@ import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
  * A reference to an actor in the network.
  */
 @Serializable
-class ActorDefsProfileViewBasic {
-    lateinit var did: String
-
+data class ActorDefsProfileViewBasic(
+    var did: String = "",
     // required but some implementations may not provide it (e.g. post.reply.root.author.handle)
-    var handle: String = ""
-
-    var displayName: String? = null
-    var avatar: String? = null
-    var viewer: ActorDefsViewerState? = null
-    var associated: ActorDefsProfileAssociated? = null
-    var labels: List<LabelDefsLabel>? = null
-    var createdAt: String? = null
-    var verification: ActorDefsVerificationState? = null
-}
+    var handle: String = "",
+    var displayName: String? = null,
+    var avatar: String? = null,
+    var viewer: ActorDefsViewerState? = null,
+    var associated: ActorDefsProfileAssociated? = null,
+    var labels: List<LabelDefsLabel>? = null,
+    var createdAt: String? = null,
+    var verification: ActorDefsVerificationState? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeed.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeed.kt
@@ -3,10 +3,10 @@ package work.socialhub.kbsky.model.app.bsky.actor
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ActorDefsSavedFeed(
-    val id: String,
+data class ActorDefsSavedFeed(
+    val id: String = "",
     // knownValues: ['feed', 'list', 'timeline']
-    val type: String,
-    val value: String,
-    val pinned: Boolean,
+    val type: String = "",
+    val value: String = "",
+    val pinned: Boolean = false,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeedsPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeedsPref.kt
@@ -5,18 +5,19 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsSavedFeedsPref : ActorDefsPreferencesUnion() {
+data class ActorDefsSavedFeedsPref(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    /** at-url  */
+    var pinned: List<String> = emptyList(),
+    /** at-url  */
+    var saved: List<String> = emptyList(),
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#savedFeedsPref"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    /** at-url  */
-    lateinit var pinned: List<String>
-
-    /** at-url  */
-    lateinit var saved: List<String>
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, emptyList(), emptyList())
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeedsPrefV2.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsSavedFeedsPrefV2.kt
@@ -5,14 +5,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsSavedFeedsPrefV2 : ActorDefsPreferencesUnion() {
+data class ActorDefsSavedFeedsPrefV2(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var items: List<ActorDefsSavedFeed> = emptyList(),
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#savedFeedsPrefV2"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var items: List<ActorDefsSavedFeed>
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, emptyList())
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsThreadViewPref.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsThreadViewPref.kt
@@ -5,21 +5,22 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class ActorDefsThreadViewPref : ActorDefsPreferencesUnion() {
+data class ActorDefsThreadViewPref(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    /**
+     * Sorting mode for threads.
+     * ["oldest", "newest", "most-likes", "random"]
+     */
+    var sort: String? = null,
+    /** Show followed users at the top of all replies. */
+    var prioritizeFollowedUsers: Boolean? = null,
+) : ActorDefsPreferencesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorDefs + "#threadViewPref"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    /**
-     * Sorting mode for threads.
-     * ["oldest", "newest", "most-likes", "random"]
-     */
-    var sort: String? = null
-
-    /** Show followed users at the top of all replies. */
-    var prioritizeFollowedUsers: Boolean? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsViewerState.kt
@@ -3,19 +3,14 @@ package work.socialhub.kbsky.model.app.bsky.actor
 import kotlinx.serialization.Serializable
 
 @Serializable
-class ActorDefsViewerState {
-
-    var muted: Boolean? = null
-    var blockedBy: Boolean? = null
-
+data class ActorDefsViewerState(
+    var muted: Boolean? = null,
+    var blockedBy: Boolean? = null,
     /** at-uri  */
-    var blocking: String? = null
-
+    var blocking: String? = null,
     /** at-uri  */
-    var following: String? = null
-
+    var following: String? = null,
     /** at-uri  */
-    var followedBy: String? = null
-
-    val knownFollowers: ActorDefsKnownFollowers? = null
-}
+    var followedBy: String? = null,
+    val knownFollowers: ActorDefsKnownFollowers? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorProfile.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorProfile.kt
@@ -8,18 +8,20 @@ import work.socialhub.kbsky.model.share.Blob
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-class ActorProfile : RecordUnion() {
+data class ActorProfile(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var displayName: String? = null,
+    var description: String? = null,
+    var avatar: Blob? = null,
+    var banner: Blob? = null,
+    var pinnedPost: RepoStrongRef? = null,
+) : RecordUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.ActorProfile
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var displayName: String? = null
-    var description: String? = null
-    var avatar: Blob? = null
-    var banner: Blob? = null
-    var pinnedPost: RepoStrongRef? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null, null, null, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternal.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternal.kt
@@ -8,14 +8,16 @@ import work.socialhub.kbsky.BlueskyTypes
  * A representation of some externally linked content, embedded in another form of content
  */
 @Serializable
-class EmbedExternal : EmbedUnion() {
+data class EmbedExternal(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var external: EmbedExternalExternal? = null,
+) : EmbedUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedExternal
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var external: EmbedExternalExternal? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternalExternal.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternalExternal.kt
@@ -4,9 +4,9 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.share.Blob
 
 @Serializable
-class EmbedExternalExternal {
-    lateinit var uri: String
-    lateinit var title: String
-    lateinit var description: String
-    var thumb: Blob? = null
-}
+data class EmbedExternalExternal(
+    var uri: String = "",
+    var title: String = "",
+    var description: String = "",
+    var thumb: Blob? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternalView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternalView.kt
@@ -5,14 +5,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedExternalView : EmbedViewUnion() {
+data class EmbedExternalView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var external: EmbedExternalViewExternal? = null,
+) : EmbedViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedExternal + "#view"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var external: EmbedExternalViewExternal? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternalViewExternal.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedExternalViewExternal.kt
@@ -3,10 +3,9 @@ package work.socialhub.kbsky.model.app.bsky.embed
 import kotlinx.serialization.Serializable
 
 @Serializable
-class EmbedExternalViewExternal {
-
-    lateinit var uri: String
-    lateinit var title: String
-    lateinit var description: String
-    var thumb: String? = null
-}
+data class EmbedExternalViewExternal(
+    var uri: String = "",
+    var title: String = "",
+    var description: String = "",
+    var thumb: String? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImages.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImages.kt
@@ -8,14 +8,16 @@ import work.socialhub.kbsky.BlueskyTypes
  * A set of images embedded in some other form of content
  */
 @Serializable
-class EmbedImages : EmbedUnion() {
+data class EmbedImages(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var images: List<EmbedImagesImage>? = null,
+) : EmbedUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedImages
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var images: List<EmbedImagesImage>? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesImage.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesImage.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.share.Blob
 
 @Serializable
-class EmbedImagesImage {
-    var image: Blob? = null
-    var alt: String? = null
-    var aspectRatio: EmbedDefsAspectRatio? = null
-}
+data class EmbedImagesImage(
+    var image: Blob? = null,
+    var alt: String? = null,
+    var aspectRatio: EmbedDefsAspectRatio? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedImagesView.kt
@@ -5,14 +5,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedImagesView : EmbedViewUnion() {
+data class EmbedImagesView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var images: List<EmbedImagesViewImage>? = null,
+) : EmbedViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedImages + "#view"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var images: List<EmbedImagesViewImage>? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecord.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecord.kt
@@ -6,14 +6,16 @@ import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
 
 @Serializable
-class EmbedRecord : EmbedUnion() {
+data class EmbedRecord(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var record: RepoStrongRef? = null,
+) : EmbedUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecord
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var record: RepoStrongRef? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordView.kt
@@ -8,14 +8,16 @@ import work.socialhub.kbsky.BlueskyTypes
  * A representation of a record embedded in another form of content
  */
 @Serializable
-class EmbedRecordView : EmbedViewUnion() {
+data class EmbedRecordView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var record: EmbedRecordViewUnion? = null,
+) : EmbedViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecord + "#view"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var record: EmbedRecordViewUnion? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewBlocked.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewBlocked.kt
@@ -5,14 +5,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedRecordViewBlocked : EmbedRecordViewUnion() {
+data class EmbedRecordViewBlocked(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var uri: String? = null,
+) : EmbedRecordViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecord + "#viewBlocked"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var uri: String? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewDetached.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewDetached.kt
@@ -5,16 +5,17 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedRecordViewDetached : EmbedRecordViewUnion() {
+data class EmbedRecordViewDetached(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var uri: String? = null,
+    var detached: Boolean = true,
+) : EmbedRecordViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecord + "#viewDetached"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var uri: String? = null
-
-    var detached: Boolean = true
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null, true)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewNotFound.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewNotFound.kt
@@ -5,14 +5,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedRecordViewNotFound : EmbedRecordViewUnion() {
+data class EmbedRecordViewNotFound(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var uri: String? = null,
+) : EmbedRecordViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecord + "#viewNotFound"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var uri: String? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewRecord.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewRecord.kt
@@ -8,20 +8,22 @@ import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-class EmbedRecordViewRecord : EmbedRecordViewUnion() {
+data class EmbedRecordViewRecord(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var uri: String? = null,
+    var cid: String? = null,
+    var author: ActorDefsProfileViewBasic? = null,
+    var value: RecordUnion? = null,
+    var labels: List<LabelDefsLabel>? = null,
+    var embeds: List<EmbedViewUnion>? = null,
+    var indexedAt: String? = null,
+) : EmbedRecordViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecord + "#viewRecord"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var uri: String? = null
-    var cid: String? = null
-    var author: ActorDefsProfileViewBasic? = null
-    var value: RecordUnion? = null
-    var labels: List<LabelDefsLabel>? = null
-    var embeds: List<EmbedViewUnion>? = null
-    var indexedAt: String? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null, null, null, null, null, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordWithMedia.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordWithMedia.kt
@@ -5,17 +5,18 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedRecordWithMedia : EmbedUnion() {
+data class EmbedRecordWithMedia(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var record: EmbedRecord? = null,
+    /** only external and images  */
+    var media: EmbedUnion? = null,
+) : EmbedUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecordWithMedia
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var record: EmbedRecord? = null
-
-    /** only external and images  */
-    var media: EmbedUnion? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordWithMediaView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordWithMediaView.kt
@@ -5,17 +5,18 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedRecordWithMediaView : EmbedViewUnion() {
+data class EmbedRecordWithMediaView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var record: EmbedRecordView? = null,
+    /** only external and images  */
+    var media: EmbedViewUnion? = null,
+) : EmbedViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedRecordWithMedia + "#view"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var record: EmbedRecordView? = null
-
-    /** only external and images  */
-    var media: EmbedViewUnion? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideo.kt
@@ -9,21 +9,20 @@ import work.socialhub.kbsky.model.share.Blob
  * A video embedded in a Bluesky record
  */
 @Serializable
-class EmbedVideo : EmbedUnion() {
+data class EmbedVideo(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var video: Blob? = null,
+    // TODO Add support for captions
+    // var captions: List<EmbedVideoCaption>? = null
+    var alt: String? = null,
+    var aspectRatio: EmbedDefsAspectRatio? = null,
+) : EmbedUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedVideo
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    var video: Blob? = null
-
-    // TODO Add support for captions
-    // var captions: List<EmbedVideoCaption>? = null
-
-    var alt: String? = null
-
-    var aspectRatio: EmbedDefsAspectRatio? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, null, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideoView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideoView.kt
@@ -5,23 +5,21 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class EmbedVideoView : EmbedViewUnion() {
+data class EmbedVideoView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var cid: String = "",
+    // uri
+    var playlist: String = "",
+    var thumbnail: String? = null,
+    var alt: String? = null,
+    var aspectRatio: EmbedDefsAspectRatio? = null,
+) : EmbedViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.EmbedVideo + "#view"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
-
-    lateinit var cid: String
-
-    // uri
-    lateinit var playlist: String
-
-    var thumbnail: String? = null
-
-    var alt: String? = null
-
-    var aspectRatio: EmbedDefsAspectRatio? = null
+    @Deprecated("use primary constructor", level = DeprecationLevel.HIDDEN)
+    constructor() : this(TYPE, "", "", null, null, null)
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsFeedViewPost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsFeedViewPost.kt
@@ -3,8 +3,8 @@ package work.socialhub.kbsky.model.app.bsky.feed
 import kotlinx.serialization.Serializable
 
 @Serializable
-class FeedDefsFeedViewPost {
-    lateinit var post: FeedDefsPostView
-    var reply: FeedDefsReplyRef? = null
-    var reason: FeedDefsReasonUnion? = null
-}
+data class FeedDefsFeedViewPost(
+    var post: FeedDefsPostView = FeedDefsPostView(),
+    var reply: FeedDefsReplyRef? = null,
+    var reason: FeedDefsReasonUnion? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsGeneratorView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsGeneratorView.kt
@@ -8,24 +8,25 @@ import work.socialhub.kbsky.model.app.bsky.embed.EmbedRecordViewUnion
 import work.socialhub.kbsky.model.app.bsky.richtext.RichtextFacet
 
 @Serializable
-class FeedDefsGeneratorView : EmbedRecordViewUnion() {
+data class FeedDefsGeneratorView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var uri: String? = null,
+    var cid: String? = null,
+    var did: String? = null,
+    var creator: ActorDefsProfileView? = null,
+    var displayName: String? = null,
+    var description: String? = null,
+    var descriptionFacets: List<RichtextFacet>? = null,
+    var avatar: String? = null,
+    var likeCount: Int? = null,
+    var viewer: FeedDefsGeneratorViewerState? = null,
+    var indexedAt: String? = null,
+) : EmbedRecordViewUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.FeedDefs + "#generatorView"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
 
-    var uri: String? = null
-    var cid: String? = null
-    var did: String? = null
-    var creator: ActorDefsProfileView? = null
-    var displayName: String? = null
-    var description: String? = null
-    var descriptionFacets: List<RichtextFacet>? = null
-    var avatar: String? = null
-    var likeCount: Int? = null
-    var viewer: FeedDefsGeneratorViewerState? = null
-    var indexedAt: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsGeneratorViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsGeneratorViewerState.kt
@@ -3,7 +3,7 @@ package work.socialhub.kbsky.model.app.bsky.feed
 import kotlinx.serialization.Serializable
 
 @Serializable
-class FeedDefsGeneratorViewerState {
+data class FeedDefsGeneratorViewerState(
     /** at-url  */
-    var like: String? = null
-}
+    var like: String? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
@@ -7,18 +7,18 @@ import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-class FeedDefsPostView {
-    var uri: String? = null
-    var cid: String? = null
-    var author: ActorDefsProfileViewBasic? = null
-    var record: RecordUnion? = null
-    var embed: EmbedViewUnion? = null
-    var replyCount: Int? = null
-    var repostCount: Int? = null
-    var likeCount: Int? = null
-    var quoteCount: Int? = null
-    var indexedAt: String? = null
-    var viewer: FeedDefsViewerState? = null
-    var labels: List<LabelDefsLabel>? = null
-    var threadgate: FeedDefsThreadgateView? = null
-}
+data class FeedDefsPostView(
+    var uri: String? = null,
+    var cid: String? = null,
+    var author: ActorDefsProfileViewBasic? = null,
+    var record: RecordUnion? = null,
+    var embed: EmbedViewUnion? = null,
+    var replyCount: Int? = null,
+    var repostCount: Int? = null,
+    var likeCount: Int? = null,
+    var quoteCount: Int? = null,
+    var indexedAt: String? = null,
+    var viewer: FeedDefsViewerState? = null,
+    var labels: List<LabelDefsLabel>? = null,
+    var threadgate: FeedDefsThreadgateView? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonPin.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonPin.kt
@@ -5,12 +5,14 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class FeedDefsReasonPin : FeedDefsReasonUnion() {
+data class FeedDefsReasonPin(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+) : FeedDefsReasonUnion() {
 
     companion object {
         val TYPE = BlueskyTypes.FeedDefs + "#reasonPin"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
+
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonRepost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonRepost.kt
@@ -6,15 +6,16 @@ import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewBasic
 
 @Serializable
-class FeedDefsReasonRepost : FeedDefsReasonUnion() {
+data class FeedDefsReasonRepost(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var by: ActorDefsProfileViewBasic? = null,
+    var indexedAt: String? = null,
+) : FeedDefsReasonUnion() {
 
     companion object {
         val TYPE = BlueskyTypes.FeedDefs + "#reasonRepost"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
 
-    var by: ActorDefsProfileViewBasic? = null
-    var indexedAt: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedGetLikesLike.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedGetLikesLike.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 
 @Serializable
-class FeedGetLikesLike {
-    lateinit var indexedAt: String
-    lateinit var createdAt: String
-    lateinit var actor: ActorDefsProfileView
-}
+data class FeedGetLikesLike(
+    var indexedAt: String = "",
+    var createdAt: String = "",
+    var actor: ActorDefsProfileView = ActorDefsProfileView(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedPostgateDisableRule.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedPostgateDisableRule.kt
@@ -5,12 +5,14 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class FeedPostgateDisableRule : FeedPostgateEmbeddingRulesUnion() {
+data class FeedPostgateDisableRule(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+) : FeedPostgateEmbeddingRulesUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.FeedPostgate + "#disableRule"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
+
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateFollowingRule.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateFollowingRule.kt
@@ -5,12 +5,14 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class FeedThreadgateFollowingRule : FeedThreadgateAllowUnion() {
+data class FeedThreadgateFollowingRule(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+) : FeedThreadgateAllowUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.FeedThreadgate + "#followingRule"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
+
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateListRule.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateListRule.kt
@@ -5,15 +5,16 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class FeedThreadgateListRule : FeedThreadgateAllowUnion() {
+data class FeedThreadgateListRule(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    // at-uri
+    var list: String = "",
+) : FeedThreadgateAllowUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.FeedThreadgate + "#listRule"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
 
-    // at-uri
-    lateinit var list: String
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateMentionRule.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateMentionRule.kt
@@ -5,12 +5,14 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class FeedThreadgateMentionRule : FeedThreadgateAllowUnion() {
+data class FeedThreadgateMentionRule(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+) : FeedThreadgateAllowUnion() {
 
     companion object {
         const val TYPE = BlueskyTypes.FeedThreadgate + "#mentionRule"
     }
 
-    @SerialName("\$type")
-    override var type = TYPE
+
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/notification/NotificationListNotificationsNotification.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/notification/NotificationListNotificationsNotification.kt
@@ -20,6 +20,6 @@ data class NotificationListNotificationsNotification(
     var record: RecordUnion? = null,
     var isRead: Boolean = false,
     var indexedAt: String = "",
-
+) {
     // TODO: labels
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/notification/NotificationListNotificationsNotification.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/notification/NotificationListNotificationsNotification.kt
@@ -5,21 +5,21 @@ import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileView
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-class NotificationListNotificationsNotification {
-    lateinit var uri: String
-    lateinit var cid: String
-    lateinit var author: ActorDefsProfileView
+data class NotificationListNotificationsNotification(
+    var uri: String = "",
+    var cid: String = "",
+    var author: ActorDefsProfileView = ActorDefsProfileView(),
 
     /**
      * Expected values are 'like', 'repost', 'follow
      * (like, repost, follow, mention, reply, quote)
      */
-    lateinit var reason: String
-    var reasonSubject: String? = null
+    var reason: String = "",
+    var reasonSubject: String? = null,
 
-    lateinit var record: RecordUnion
-    var isRead: Boolean = false
-    lateinit var indexedAt: String
+    var record: RecordUnion? = null,
+    var isRead: Boolean = false,
+    var indexedAt: String = "",
 
     // TODO: labels
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetTag.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/richtext/RichtextFacetTag.kt
@@ -5,10 +5,10 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.BlueskyTypes
 
 @Serializable
-class RichtextFacetTag(
+data class RichtextFacetTag(
     @SerialName("\$type")
     override var type: String = TYPE,
-    var tag: String,
+    var tag: String = "",
 ) : RichtextFacetFeatureUnion() {
 
     companion object {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/undoc/UndocSearchFeedsPost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/undoc/UndocSearchFeedsPost.kt
@@ -3,8 +3,8 @@ package work.socialhub.kbsky.model.app.bsky.undoc
 import kotlinx.serialization.Serializable
 
 @Serializable
-class UndocSearchFeedsPost {
-    var createdAt: Long? = null
-    var text: String? = null
-    var user: String? = null
-}
+data class UndocSearchFeedsPost(
+    var createdAt: Long? = null,
+    var text: String? = null,
+    var user: String? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/undoc/UndocSearchFeedsUser.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/undoc/UndocSearchFeedsUser.kt
@@ -3,7 +3,7 @@ package work.socialhub.kbsky.model.app.bsky.undoc
 import kotlinx.serialization.Serializable
 
 @Serializable
-class UndocSearchFeedsUser {
-    var did: String? = null
-    var handle: String? = null
-}
+data class UndocSearchFeedsUser(
+    var did: String? = null,
+    var handle: String? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsProfileViewBasic.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsProfileViewBasic.kt
@@ -10,14 +10,14 @@ import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
  * chat.bsky.actor.defs#profileViewBasic
  */
 @Serializable
-class ActorDefsProfileViewBasic {
-    lateinit var did: String
-    lateinit var handle: String
-    var displayName: String? = null
-    var avatar: String? = null
-    var associated: ActorDefsProfileAssociated? = null
-    var viewer: ActorDefsViewerState? = null
-    var labels: List<LabelDefsLabel>? = null
-    var chatDisabled: Boolean = false
-    var verification: ActorDefsVerificationState? = null
-}
+data class ActorDefsProfileViewBasic(
+    var did: String = "",
+    var handle: String = "",
+    var displayName: String? = null,
+    var avatar: String? = null,
+    var associated: ActorDefsProfileAssociated? = null,
+    var viewer: ActorDefsViewerState? = null,
+    var labels: List<LabelDefsLabel>? = null,
+    var chatDisabled: Boolean = false,
+    var verification: ActorDefsVerificationState? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoListRecordsRecord.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoListRecordsRecord.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
-class RepoListRecordsRecord {
-    var uri: String? = null
-    var cid: String? = null
-    var value: RecordUnion? = null
-}
+data class RepoListRecordsRecord(
+    var uri: String? = null,
+    var cid: String? = null,
+    var value: RecordUnion? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
@@ -6,22 +6,7 @@ import kotlinx.serialization.Serializable
  * A URI with a content-hash fingerprint.
  */
 @Serializable
-class RepoStrongRef(
-    var uri: String,
-    var cid: String,
-) {
-
-    override fun equals(other: Any?): Boolean {
-        val ref = other as? RepoStrongRef ?: return false
-        return (ref.uri == uri) && (ref.cid == cid)
-    }
-
-    override fun hashCode(): Int {
-        var res = 0
-        for (v in listOf(uri, cid)) {
-            res += v.hashCode()
-            res *= 31
-        }
-        return res
-    }
-}
+data class RepoStrongRef(
+    var uri: String = "",
+    var cid: String = "",
+)


### PR DESCRIPTION
## Summary
- convert remaining POJO-style classes to Kotlin `data class`
- update request objects like `FeedPostRequest` and `FeedGetAuthorFeedRequest`
- convert feed, notification and actor model classes

## Testing
- ❌ `./gradlew build --no-daemon` (failed: missing JDK 11)
- ❌ `./gradlew test --no-daemon` (failed: Task 'test' not found)


------
https://chatgpt.com/codex/tasks/task_e_684a19e42940832aa7e1ba1d656a52ef