### PR TITLE
version up dokka.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .gradle
 .kotlin
+.prompts
 target/
 build/
 out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,9 @@ Since this is primarily a client library for SNS, testing generally requires a u
 ```shell
 ./gradlew core:jvmTest --tests "work.socialhub.kbsky.com.atproto.identity.ResolveHandleTest.testResolveHandle"
 ```
+
+If you cannot access the Bluesky server, please verify that the build is successful. In the JVM environment, you can check compilation with the following command:
+
+```shell
+./gradlew jvmJar
+```

--- a/docs/AGENTS_ja.md
+++ b/docs/AGENTS_ja.md
@@ -7,3 +7,9 @@
 ```shell
 ./gradlew core:jvmTest --tests "work.socialhub.kbsky.com.atproto.identity.ResolveHandleTest.testResolveHandle"
 ```
+
+Bluesky のサーバーにアクセス出来ない場合は、ビルドができることを確認してください。JVM 環境では以下でコンパイルの確認ができます。
+
+```shell
+./gradlew jvmJar
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ org.gradle.jvmargs=-Xmx3g
 kotlin.code.style=official
 kotlin.daemon.jvm.options=-Xmx3g
 
+# Dokka
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/plugins/src/main/kotlin/module.publications.gradle.kts
+++ b/plugins/src/main/kotlin/module.publications.gradle.kts
@@ -6,8 +6,9 @@ plugins {
     id("maven-publish")
     id("signing")
 
-    id("com.vanniktech.maven.publish")
     id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
+    id("com.vanniktech.maven.publish")
 }
 
 publishing {
@@ -55,7 +56,7 @@ publishing {
 mavenPublishing {
     configure(
         KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka("dokkaHtml")
+            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationJavadoc")
         )
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for verifying successful builds without Bluesky server access, including new guidance for JVM environments in both English and Japanese documentation.

- **Chores**
  - Updated `.gitignore` to exclude `.prompts` files and directories.
  - Enabled experimental Dokka Gradle plugin mode and suppressed related warnings.
  - Adjusted plugin order and documentation generation task for publishing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->