### PR TITLE
Include Kotlin stdlib for JVM modules

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -43,6 +43,10 @@ kotlin {
             api(project(":core"))
             api(project(":stream"))
         }
+
+        jvmMain.dependencies {
+            api(kotlin("stdlib"))
+        }
     }
 }
 

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -34,6 +34,10 @@ kotlin {
             implementation(libs.cryptography.core)
         }
 
+        jvmMain.dependencies {
+            api(kotlin("stdlib"))
+        }
+
         appleMain.dependencies {
             implementation(libs.cryptography.openssl)
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,6 +30,10 @@ kotlin {
             implementation(libs.serialization.json)
         }
 
+        jvmMain.dependencies {
+            api(kotlin("stdlib"))
+        }
+
         // for test
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -31,6 +31,10 @@ kotlin {
             implementation(libs.serialization.cbor)
         }
 
+        jvmMain.dependencies {
+            api(kotlin("stdlib"))
+        }
+
         // for test (kotlin/jvm)
         jvmTest.dependencies {
             implementation(kotlin("test"))


### PR DESCRIPTION
FIx https://github.com/uakihir0/kbsky/issues/182

## Summary
- add `kotlin("stdlib")` as a transitive dependency for JVM targets

## Testing
- `./gradlew core:jvmTest --tests work.socialhub.kbsky.com.atproto.identity.ResolveHandleTest.testResolveHandle` *(fails: There were failing tests)*
- `./gradlew jvmJar`


------
https://chatgpt.com/codex/tasks/task_e_68568e0aa7ec832a9bfb6b477aa471a3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration to explicitly include the Kotlin standard library as a dependency for JVM targets across multiple modules. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->