### PR TITLE
Restore JDK step line

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,14 @@
 # Gradle
 org.gradle.jvmargs=-Xmx3g
 
+# Enable faster builds
+org.gradle.parallel=true
+org.gradle.daemon=true
+
 # Kotlin
 kotlin.code.style=official
 kotlin.daemon.jvm.options=-Xmx3g
+kotlin.incremental=true
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary
- keep newline after `actions/checkout@v3` in CI workflow
- keep previously added build performance flags

## Testing
- `./gradlew jvmJar`


------
https://chatgpt.com/codex/tasks/task_e_685b3e7bf0d4832ab627e89bbbcc0244