### PR TITLE
Support like/repost via reposts (and update ktor)

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedLikeRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedLikeRequest.kt
@@ -12,19 +12,23 @@ data class FeedLikeRequest(
     override val auth: AuthProvider,
     var subject: RepoStrongRef? = null,
     override var createdAt: String? = null,
+    val via: RepoStrongRef? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {
             it.addParam("subject", toJson(subject))
             it.addParam("createdAt", createdAt())
+            it.addParam("via", toJson(via))
         }
     }
 
     fun toLike(): FeedLike {
-        val like = FeedLike()
-        like.subject = subject
-        like.createdAt = createdAt()
+        val like = FeedLike(
+            subject = subject,
+            createdAt = createdAt(),
+            via = via,
+        )
         return like
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedRepostRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedRepostRequest.kt
@@ -12,19 +12,23 @@ data class FeedRepostRequest(
     override val auth: AuthProvider,
     var subject: RepoStrongRef? = null,
     override var createdAt: String? = null,
+    val via: RepoStrongRef? = null,
 ) : AuthRequest(auth), MapRequest, RecordRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {
             it.addParam("subject", toJson(subject))
             it.addParam("createdAt", createdAt())
+            it.addParam("via", toJson(via))
         }
     }
 
     fun toRepost(): FeedRepost {
-        val repost = FeedRepost()
-        repost.subject = subject
-        repost.createdAt = createdAt()
+        val repost = FeedRepost(
+            subject = subject,
+            createdAt = createdAt(),
+            via = via,
+        )
         return repost
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonRepost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsReasonRepost.kt
@@ -10,6 +10,8 @@ data class FeedDefsReasonRepost(
     @SerialName("\$type")
     override var type: String = TYPE,
     var by: ActorDefsProfileViewBasic? = null,
+    var uri: String? = null,
+    var cid: String? = null,
     var indexedAt: String? = null,
 ) : FeedDefsReasonUnion() {
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedLike.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedLike.kt
@@ -12,6 +12,7 @@ data class FeedLike(
     override var type: String = TYPE,
     var subject: RepoStrongRef? = null,
     var createdAt: String? = null,
+    val via: RepoStrongRef? = null,
 ) : RecordUnion() {
     companion object {
         const val TYPE = BlueskyTypes.FeedLike

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedRepost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedRepost.kt
@@ -12,6 +12,7 @@ data class FeedRepost(
     override var type: String = TYPE,
     var subject: RepoStrongRef? = null,
     var createdAt: String? = null,
+    val via: RepoStrongRef? = null,
 ) : RecordUnion() {
     companion object {
         const val TYPE = BlueskyTypes.FeedRepost

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ coroutines = "1.10.2"
 
 [libraries]
 khttpclient = "work.socialhub:khttpclient:0.0.5"
-ktor-core = "io.ktor:ktor-client-core:3.2.0"
+ktor-core = "io.ktor:ktor-client-core:3.2.1"
 datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.2"
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
Added via field to like and repost requests to support `repost-via-repost` and `like-via-repost`.

----

「リポストのリポスト」「リポストのいいね」に対応するために like, repost のリクエストに via フィールドを追加しました。

また、これに必要な repost 自体の uri, cid を取得するために FeedDefsReasonRepost に uri と cid フィールドを追加しました。

さらに、Android でビルドできなくなっていたので Ktor client を 3.2.0 から 3.2.1 に更新しました。