### PR TITLE
Add follower rule of thread-gate

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateAllowUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateAllowUnion.kt
@@ -7,6 +7,7 @@ import work.socialhub.kbsky.util.json.ThreadgateAllowUnionPolymorphicSerializer
 /**
  * @see FeedThreadgateMentionRule
  * @see FeedThreadgateFollowingRule
+ * @see FeedThreadgateFollowerRule
  * @see FeedThreadgateListRule
  */
 @Serializable(with = ThreadgateAllowUnionPolymorphicSerializer::class)
@@ -16,5 +17,6 @@ abstract class FeedThreadgateAllowUnion {
 
     val asThreadgateMentionRule get() = this as? FeedThreadgateMentionRule
     val asThreadgateFollowingRule get() = this as? FeedThreadgateFollowingRule
+    val asThreadgateFollowerRule get() = this as? FeedThreadgateFollowerRule
     val asThreadgateListRule get() = this as? FeedThreadgateListRule
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateFollowerRule.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedThreadgateFollowerRule.kt
@@ -1,0 +1,17 @@
+package work.socialhub.kbsky.model.app.bsky.feed
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+
+@Serializable
+data class FeedThreadgateFollowerRule(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+) : FeedThreadgateAllowUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.FeedThreadgate + "#followerRule"
+    }
+
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ThreadgateAllowUnionPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ThreadgateAllowUnionPolymorphicSerializer.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
 import work.socialhub.kbsky.model.app.bsky.feed.FeedThreadgateAllowUnion
+import work.socialhub.kbsky.model.app.bsky.feed.FeedThreadgateFollowerRule
 import work.socialhub.kbsky.model.app.bsky.feed.FeedThreadgateFollowingRule
 import work.socialhub.kbsky.model.app.bsky.feed.FeedThreadgateListRule
 import work.socialhub.kbsky.model.app.bsky.feed.FeedThreadgateMentionRule
@@ -21,6 +22,7 @@ object ThreadgateAllowUnionPolymorphicSerializer :
         return when (val type = element.type()) {
             FeedThreadgateMentionRule.TYPE -> FeedThreadgateMentionRule.serializer()
             FeedThreadgateFollowingRule.TYPE -> FeedThreadgateFollowingRule.serializer()
+            FeedThreadgateFollowerRule.TYPE -> FeedThreadgateFollowerRule.serializer()
             FeedThreadgateListRule.TYPE -> FeedThreadgateListRule.serializer()
             else -> {
                 println("[Warning] Unknown Item type: $type (ThreadgateAllowUnion)")


### PR DESCRIPTION
Support "follower" rule.

----

いわゆる「返信の設定」の選択肢「フォロワー」に対応しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for follower-based thread access rules, allowing the app to recognize and enforce follower-only participation in conversations.
  * Enhanced handling of thread permissions, ensuring threads with follower restrictions load and display correctly.
  * Improved compatibility with services using the new rule, providing a more consistent experience when interacting with feeds that restrict replies or visibility to followers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->