### PR TITLE
Add moderation API (createReport)

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocol.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/ATProtocol.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky
 
 import work.socialhub.kbsky.api.com.atproto.IdentityResource
+import work.socialhub.kbsky.api.com.atproto.ModerationResource
 import work.socialhub.kbsky.api.com.atproto.RepoResource
 import work.socialhub.kbsky.api.com.atproto.ServerResource
 
@@ -8,4 +9,5 @@ interface ATProtocol {
     fun identity(): IdentityResource
     fun server(): ServerResource
     fun repo(): RepoResource
+    fun moderation(): ModerationResource
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/ModerationResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/ModerationResource.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.api.com.atproto
+
+import work.socialhub.kbsky.api.entity.com.atproto.moderation.ModerationCreateReportRequest
+import work.socialhub.kbsky.api.entity.com.atproto.moderation.ModerationCreateReportResponse
+import work.socialhub.kbsky.api.entity.share.Response
+
+/**
+ * ATProtocol/Moderation
+ * [Reference](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/moderation)
+ */
+interface ModerationResource {
+
+    /**
+     * レポートを作成する
+     */
+    fun createReport(
+        request: ModerationCreateReportRequest
+    ): Response<ModerationCreateReportResponse>
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/moderation/ModerationCreateReportRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/moderation/ModerationCreateReportRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.com.atproto.moderation
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import work.socialhub.kbsky.model.com.atproto.moderation.ModerationSubjectUnion
+
+data class ModerationCreateReportRequest(
+    val reasonType: String,
+    val reason: String? = null,
+    val subject: ModerationSubjectUnion,
+    override val auth: AuthProvider
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("reasonType", reasonType)
+            it.addParam("reason", reason)
+            it.addParam("subject", subject.toMap())
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/moderation/ModerationCreateReportRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/moderation/ModerationCreateReportRequest.kt
@@ -16,7 +16,7 @@ data class ModerationCreateReportRequest(
         return mutableMapOf<String, Any>().also {
             it.addParam("reasonType", reasonType)
             it.addParam("reason", reason)
-            it.addParam("subject", subject.toMap())
+            it.addParam("subject", subject)
         }
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/moderation/ModerationCreateReportResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/com/atproto/moderation/ModerationCreateReportResponse.kt
@@ -1,0 +1,7 @@
+package work.socialhub.kbsky.api.entity.com.atproto.moderation
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.com.atproto.moderation.ModerationReport
+
+@Serializable
+class ModerationCreateReportResponse : ModerationReport()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_ATProtocol.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/_ATProtocol.kt
@@ -3,9 +3,11 @@ package work.socialhub.kbsky.internal
 import work.socialhub.kbsky.ATProtocol
 import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.api.com.atproto.IdentityResource
+import work.socialhub.kbsky.api.com.atproto.ModerationResource
 import work.socialhub.kbsky.api.com.atproto.RepoResource
 import work.socialhub.kbsky.api.com.atproto.ServerResource
 import work.socialhub.kbsky.internal.com.atproto._IdentityResource
+import work.socialhub.kbsky.internal.com.atproto._ModerationResource
 import work.socialhub.kbsky.internal.com.atproto._RepoResource
 import work.socialhub.kbsky.internal.com.atproto._ServerResource
 
@@ -16,6 +18,7 @@ open class _ATProtocol(
     protected val identity: IdentityResource = _IdentityResource(config)
     protected val server: ServerResource = _ServerResource(config)
     protected val repo: RepoResource = _RepoResource(config)
+    protected val moderation: ModerationResource = _ModerationResource(config)
 
     /**
      * {@inheritDoc}
@@ -31,4 +34,9 @@ open class _ATProtocol(
      * {@inheritDoc}
      */
     override fun repo() = repo
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun moderation() = moderation
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_ModerationResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/com/atproto/_ModerationResource.kt
@@ -1,0 +1,33 @@
+package work.socialhub.kbsky.internal.com.atproto
+
+import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.ATProtocolConfig
+import work.socialhub.kbsky.ATProtocolTypes.ModerationCreateReport
+import work.socialhub.kbsky.api.com.atproto.ModerationResource
+import work.socialhub.kbsky.api.entity.com.atproto.moderation.ModerationCreateReportRequest
+import work.socialhub.kbsky.api.entity.com.atproto.moderation.ModerationCreateReportResponse
+import work.socialhub.kbsky.api.entity.share.Response
+import work.socialhub.kbsky.internal.share._InternalUtility.postWithAuth
+import work.socialhub.kbsky.internal.share._InternalUtility.proceed
+import work.socialhub.kbsky.internal.share._InternalUtility.xrpc
+import work.socialhub.kbsky.util.MediaType
+import work.socialhub.khttpclient.HttpRequest
+
+class _ModerationResource(
+    private val config: ATProtocolConfig
+) : ModerationResource {
+
+    override fun createReport(
+        request: ModerationCreateReportRequest
+    ): Response<ModerationCreateReportResponse> {
+        return proceed<ModerationCreateReportResponse> {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, ModerationCreateReport))
+                    .accept(MediaType.JSON)
+                    .json(request.toMappedJson())
+                    .postWithAuth(request.auth)
+            }
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationReasonType.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationReasonType.kt
@@ -1,0 +1,27 @@
+package work.socialhub.kbsky.model.com.atproto.moderation
+
+/**
+ * モデレーションレポートの理由タイプ定数
+ */
+object ModerationReasonType {
+    /** スパム: 頻繁な不要な宣伝、返信、メンション */
+    const val SPAM = "com.atproto.moderation.defs#reasonSpam"
+    
+    /** 規約違反: サーバールール、法律、利用規約の直接的な違反 */
+    const val VIOLATION = "com.atproto.moderation.defs#reasonViolation"
+    
+    /** 誤解を招く内容: 誤解を招くアイデンティティ、所属、またはコンテンツ */
+    const val MISLEADING = "com.atproto.moderation.defs#reasonMisleading"
+    
+    /** 性的コンテンツ: 不要または誤表示された性的コンテンツ */
+    const val SEXUAL = "com.atproto.moderation.defs#reasonSexual"
+    
+    /** 失礼な行為: ハラスメント、露骨な、または歓迎されない行動 */
+    const val RUDE = "com.atproto.moderation.defs#reasonRude"
+    
+    /** その他: 他のカテゴリに該当しないレポート */
+    const val OTHER = "com.atproto.moderation.defs#reasonOther"
+    
+    /** 異議申し立て: 以前に取られたモデレーション行動への異議申し立て */
+    const val APPEAL = "com.atproto.moderation.defs#reasonAppeal"
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationReport.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationReport.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.model.com.atproto.moderation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+open class ModerationReport {
+    val id: Int? = null
+    val reasonType: String? = null
+    val reason: String? = null
+    val subject: ModerationSubjectUnion? = null
+    val reportedBy: String? = null
+    val createdAt: String? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnion.kt
@@ -1,0 +1,21 @@
+package work.socialhub.kbsky.model.com.atproto.moderation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.com.atproto.repo.RepoRef
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
+
+/**
+ * @see RepoRef
+ * @see RepoStrongRef
+ */
+@Serializable(with = ModerationSubjectUnionSerializer::class)
+abstract class ModerationSubjectUnion {
+    @SerialName("\$type")
+    abstract val type: String
+
+    abstract fun toMap(): Map<String, Any>
+
+    val asRef get() = this as? RepoRef
+    val asStrongRef get() = this as? RepoStrongRef
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnion.kt
@@ -14,8 +14,6 @@ abstract class ModerationSubjectUnion {
     @SerialName("\$type")
     abstract val type: String
 
-    abstract fun toMap(): Map<String, Any>
-
     val asRef get() = this as? RepoRef
     val asStrongRef get() = this as? RepoStrongRef
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnionSerializer.kt
@@ -1,0 +1,34 @@
+package work.socialhub.kbsky.model.com.atproto.moderation
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.com.atproto.repo.RepoRef
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object ModerationSubjectUnionSerializer :
+    JsonContentPolymorphicSerializer<ModerationSubjectUnion>(
+        ModerationSubjectUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<ModerationSubjectUnion> {
+        return when (val type = element.type()) {
+            "com.atproto.admin.defs#repoRef" -> RepoRef.serializer()
+            "com.atproto.repo.strongRef" -> RepoStrongRef.serializer()
+            else -> {
+                println("[Warning] Unknown ModerationSubjectUnion type: $type")
+                Unknown.serializer()
+            }
+        }
+    }
+
+    @Serializable
+    class Unknown : ModerationSubjectUnion() {
+        override val type: String = "unknown"
+        override fun toMap(): Map<String, Any> = mapOf("\$type" to type)
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/moderation/ModerationSubjectUnionSerializer.kt
@@ -29,6 +29,5 @@ object ModerationSubjectUnionSerializer :
     @Serializable
     class Unknown : ModerationSubjectUnion() {
         override val type: String = "unknown"
-        override fun toMap(): Map<String, Any> = mapOf("\$type" to type)
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.model.com.atproto.repo
 
 import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.com.atproto.moderation.ModerationSubjectUnion
 
 /**
  * Repository reference by DID.
@@ -8,4 +9,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RepoRef(
     val did: String,
-)
+) : ModerationSubjectUnion() {
+    override val type: String = "com.atproto.admin.defs#repoRef"
+    
+    override fun toMap(): Map<String, Any> {
+        return mapOf(
+            "\$type" to type,
+            "did" to did
+        )
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
@@ -1,0 +1,11 @@
+package work.socialhub.kbsky.model.com.atproto.repo
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Repository reference by DID.
+ */
+@Serializable
+data class RepoRef(
+    val did: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
@@ -11,11 +11,4 @@ data class RepoRef(
     val did: String,
 ) : ModerationSubjectUnion() {
     override val type: String = "com.atproto.admin.defs#repoRef"
-    
-    override fun toMap(): Map<String, Any> {
-        return mapOf(
-            "\$type" to type,
-            "did" to did
-        )
-    }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoRef.kt
@@ -1,5 +1,6 @@
 package work.socialhub.kbsky.model.com.atproto.repo
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.moderation.ModerationSubjectUnion
 
@@ -10,5 +11,6 @@ import work.socialhub.kbsky.model.com.atproto.moderation.ModerationSubjectUnion
 data class RepoRef(
     val did: String,
 ) : ModerationSubjectUnion() {
+    @SerialName("\$type")
     override val type: String = "com.atproto.admin.defs#repoRef"
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.model.com.atproto.repo
 
 import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.com.atproto.moderation.ModerationSubjectUnion
 
 /**
  * A URI with a content-hash fingerprint.
@@ -9,4 +10,14 @@ import kotlinx.serialization.Serializable
 data class RepoStrongRef(
     var uri: String = "",
     var cid: String = "",
-)
+) : ModerationSubjectUnion() {
+    override val type: String = "com.atproto.repo.strongRef"
+    
+    override fun toMap(): Map<String, Any> {
+        return mapOf(
+            "\$type" to type,
+            "uri" to uri,
+            "cid" to cid
+        )
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
@@ -8,16 +8,8 @@ import work.socialhub.kbsky.model.com.atproto.moderation.ModerationSubjectUnion
  */
 @Serializable
 data class RepoStrongRef(
-    var uri: String = "",
-    var cid: String = "",
+    val uri: String = "",
+    val cid: String = "",
 ) : ModerationSubjectUnion() {
     override val type: String = "com.atproto.repo.strongRef"
-    
-    override fun toMap(): Map<String, Any> {
-        return mapOf(
-            "\$type" to type,
-            "uri" to uri,
-            "cid" to cid
-        )
-    }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/com/atproto/repo/RepoStrongRef.kt
@@ -1,5 +1,6 @@
 package work.socialhub.kbsky.model.com.atproto.repo
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import work.socialhub.kbsky.model.com.atproto.moderation.ModerationSubjectUnion
 
@@ -11,5 +12,6 @@ data class RepoStrongRef(
     val uri: String = "",
     val cid: String = "",
 ) : ModerationSubjectUnion() {
+    @SerialName("\$type")
     override val type: String = "com.atproto.repo.strongRef"
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/AnySerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/AnySerializer.kt
@@ -31,6 +31,8 @@ import work.socialhub.kbsky.model.app.bsky.graph.GraphFollow
 import work.socialhub.kbsky.model.app.bsky.graph.GraphList
 import work.socialhub.kbsky.model.app.bsky.graph.GraphListItem
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageInput
+import work.socialhub.kbsky.model.com.atproto.repo.RepoRef
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
 
 object AnySerializer : KSerializer<Any> {
 
@@ -95,6 +97,8 @@ object AnySerializer : KSerializer<Any> {
                 ConvoDefsMessageInput.serializer(),
                 value
             )
+            is RepoRef -> encoder.encodeSerializableValue(RepoRef.serializer(), value)
+            is RepoStrongRef -> encoder.encodeSerializableValue(RepoStrongRef.serializer(), value)
 
             else -> {
                 println("Can't serialize unknown type: ${value::class}")


### PR DESCRIPTION
To support moderation, I have added `moderation` class and `createReport` method.

----

例によって ZonePane で必要になり追加しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added moderation API support, including a client entry point to submit moderation reports.
  * Introduced reason type constants for easy, consistent report classification.
  * Added models for moderation reports and subject references, with polymorphic serialization and safe fallback for unknown types.

* **Refactor**
  * Updated RepoStrongRef to use immutable fields and participate in the new moderation subject union.
  * Exposed the moderation resource through the main protocol interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->