### PR TITLE
Support bookmarks

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -47,6 +47,7 @@ object BlueskyTypes {
     const val FeedGetFeedGenerator = "app.bsky.feed.getFeedGenerator"
     const val FeedGetFeedGenerators = "app.bsky.feed.getFeedGenerators"
     const val FeedCreateBookmark = "app.bsky.bookmark.createBookmark"
+    const val FeedDeleteBookmark = "app.bsky.bookmark.deleteBookmark"
     const val FeedThreadgate = "app.bsky.feed.threadgate"
     const val FeedPostgate = "app.bsky.feed.postgate"
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -46,6 +46,7 @@ object BlueskyTypes {
     const val FeedGetFeedSearchPosts = "app.bsky.feed.searchPosts"
     const val FeedGetFeedGenerator = "app.bsky.feed.getFeedGenerator"
     const val FeedGetFeedGenerators = "app.bsky.feed.getFeedGenerators"
+    const val FeedCreateBookmark = "app.bsky.bookmark.createBookmark"
     const val FeedThreadgate = "app.bsky.feed.threadgate"
     const val FeedPostgate = "app.bsky.feed.postgate"
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -48,6 +48,7 @@ object BlueskyTypes {
     const val FeedGetFeedGenerators = "app.bsky.feed.getFeedGenerators"
     const val FeedCreateBookmark = "app.bsky.bookmark.createBookmark"
     const val FeedDeleteBookmark = "app.bsky.bookmark.deleteBookmark"
+    const val FeedGetBookmarks = "app.bsky.bookmark.getBookmarks"
     const val FeedThreadgate = "app.bsky.feed.threadgate"
     const val FeedPostgate = "app.bsky.feed.postgate"
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
@@ -1,5 +1,6 @@
 package work.socialhub.kbsky.api.app.bsky
 
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedCreateBookmarkRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteLikeRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeletePostRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteRepostRequest
@@ -210,4 +211,11 @@ interface FeedResource {
     fun postgate(
         request: FeedPostgateRequest
     ): Response<FeedPostgateResponse>
+
+    /**
+     * Creates a private bookmark for the specified record.
+     */
+    fun createBookmark(
+        request: FeedCreateBookmarkRequest
+    ): Response<Unit>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.api.app.bsky
 
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedCreateBookmarkRequest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteBookmarkRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteLikeRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeletePostRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteRepostRequest
@@ -217,5 +218,12 @@ interface FeedResource {
      */
     fun createBookmark(
         request: FeedCreateBookmarkRequest
+    ): Response<Unit>
+
+    /**
+     * Deletes a private bookmark for the specified record.
+     */
+    fun deleteBookmark(
+        request: FeedDeleteBookmarkRequest
     ): Response<Unit>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
@@ -11,6 +11,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetActorLikesRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetActorLikesResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetAuthorFeedRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetAuthorFeedResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetBookmarksRequest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetBookmarksResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedGeneratorRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedGeneratorResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedGeneratorsRequest
@@ -226,4 +228,11 @@ interface FeedResource {
     fun deleteBookmark(
         request: FeedDeleteBookmarkRequest
     ): Response<Unit>
+
+    /**
+     * Gets views of records bookmarked by the authenticated user.
+     */
+    fun getBookmarks(
+        request: FeedGetBookmarksRequest
+    ): Response<FeedGetBookmarksResponse>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedCreateBookmarkRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedCreateBookmarkRequest.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+
+data class FeedCreateBookmarkRequest(
+    override val auth: AuthProvider,
+    val uri: String,
+    val cid: String,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("uri", uri)
+            it.addParam("cid", cid)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeleteBookmarkRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedDeleteBookmarkRequest.kt
@@ -1,0 +1,17 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+
+data class FeedDeleteBookmarkRequest(
+    override val auth: AuthProvider,
+    val uri: String,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("uri", uri)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetBookmarksRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetBookmarksRequest.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+
+data class FeedGetBookmarksRequest(
+    override val auth: AuthProvider,
+    val limit: Int? = null,
+    val cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetBookmarksResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetBookmarksResponse.kt
@@ -1,0 +1,10 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsBookmarkView
+
+@Serializable
+data class FeedGetBookmarksResponse(
+    val cursor: String? = null,
+    val bookmarks: List<FeedDefsBookmarkView>,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
@@ -18,12 +18,14 @@ import work.socialhub.kbsky.BlueskyTypes.FeedGetPosts
 import work.socialhub.kbsky.BlueskyTypes.FeedGetQuotes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetRepostedBy
 import work.socialhub.kbsky.BlueskyTypes.FeedGetTimeline
+import work.socialhub.kbsky.BlueskyTypes.FeedCreateBookmark
 import work.socialhub.kbsky.BlueskyTypes.FeedLike
 import work.socialhub.kbsky.BlueskyTypes.FeedPost
 import work.socialhub.kbsky.BlueskyTypes.FeedPostgate
 import work.socialhub.kbsky.BlueskyTypes.FeedRepost
 import work.socialhub.kbsky.BlueskyTypes.FeedThreadgate
 import work.socialhub.kbsky.api.app.bsky.FeedResource
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedCreateBookmarkRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteLikeRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeletePostRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteRepostRequest
@@ -476,6 +478,21 @@ class _FeedResource(
                     .url(xrpc(config, RepoCreateRecord))
                     .json(record.toMappedJson())
                     .accept(MediaType.JSON)
+                    .postWithAuth(request.auth)
+            }
+        }
+    }
+
+    override fun createBookmark(
+        request: FeedCreateBookmarkRequest
+    ): Response<Unit> {
+
+        return proceedUnit {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, FeedCreateBookmark))
+                    .accept(MediaType.JSON)
+                    .json(request.toMappedJson())
                     .postWithAuth(request.auth)
             }
         }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
@@ -19,6 +19,7 @@ import work.socialhub.kbsky.BlueskyTypes.FeedGetQuotes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetRepostedBy
 import work.socialhub.kbsky.BlueskyTypes.FeedGetTimeline
 import work.socialhub.kbsky.BlueskyTypes.FeedCreateBookmark
+import work.socialhub.kbsky.BlueskyTypes.FeedDeleteBookmark
 import work.socialhub.kbsky.BlueskyTypes.FeedLike
 import work.socialhub.kbsky.BlueskyTypes.FeedPost
 import work.socialhub.kbsky.BlueskyTypes.FeedPostgate
@@ -26,6 +27,7 @@ import work.socialhub.kbsky.BlueskyTypes.FeedRepost
 import work.socialhub.kbsky.BlueskyTypes.FeedThreadgate
 import work.socialhub.kbsky.api.app.bsky.FeedResource
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedCreateBookmarkRequest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteBookmarkRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteLikeRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeletePostRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteRepostRequest
@@ -491,6 +493,21 @@ class _FeedResource(
             runBlocking {
                 HttpRequest()
                     .url(xrpc(config, FeedCreateBookmark))
+                    .accept(MediaType.JSON)
+                    .json(request.toMappedJson())
+                    .postWithAuth(request.auth)
+            }
+        }
+    }
+
+    override fun deleteBookmark(
+        request: FeedDeleteBookmarkRequest
+    ): Response<Unit> {
+
+        return proceedUnit {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, FeedDeleteBookmark))
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())
                     .postWithAuth(request.auth)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/_FeedResource.kt
@@ -4,9 +4,12 @@ import kotlinx.coroutines.runBlocking
 import work.socialhub.kbsky.ATProtocolTypes.RepoCreateRecord
 import work.socialhub.kbsky.ATProtocolTypes.RepoDeleteRecord
 import work.socialhub.kbsky.BlueskyConfig
+import work.socialhub.kbsky.BlueskyTypes.FeedCreateBookmark
+import work.socialhub.kbsky.BlueskyTypes.FeedDeleteBookmark
 import work.socialhub.kbsky.BlueskyTypes.FeedGetActorFeeds
 import work.socialhub.kbsky.BlueskyTypes.FeedGetActorLikes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetAuthorFeed
+import work.socialhub.kbsky.BlueskyTypes.FeedGetBookmarks
 import work.socialhub.kbsky.BlueskyTypes.FeedGetFeed
 import work.socialhub.kbsky.BlueskyTypes.FeedGetFeedGenerator
 import work.socialhub.kbsky.BlueskyTypes.FeedGetFeedGenerators
@@ -18,57 +21,13 @@ import work.socialhub.kbsky.BlueskyTypes.FeedGetPosts
 import work.socialhub.kbsky.BlueskyTypes.FeedGetQuotes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetRepostedBy
 import work.socialhub.kbsky.BlueskyTypes.FeedGetTimeline
-import work.socialhub.kbsky.BlueskyTypes.FeedCreateBookmark
-import work.socialhub.kbsky.BlueskyTypes.FeedDeleteBookmark
 import work.socialhub.kbsky.BlueskyTypes.FeedLike
 import work.socialhub.kbsky.BlueskyTypes.FeedPost
 import work.socialhub.kbsky.BlueskyTypes.FeedPostgate
 import work.socialhub.kbsky.BlueskyTypes.FeedRepost
 import work.socialhub.kbsky.BlueskyTypes.FeedThreadgate
 import work.socialhub.kbsky.api.app.bsky.FeedResource
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedCreateBookmarkRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteBookmarkRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteLikeRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeletePostRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedDeleteRepostRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetActorFeedsRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetActorFeedsResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetActorLikesRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetActorLikesResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetAuthorFeedRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetAuthorFeedResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedGeneratorRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedGeneratorResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedGeneratorsRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedGeneratorsResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetFeedResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetLikesRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetLikesResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetListFeedRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetListFeedResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostThreadRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostThreadResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostsRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetPostsResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedLikeRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedLikeResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedPostRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedPostResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedPostgateRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedPostgateResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedRepostRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedRepostResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsResponse
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedThreadgateRequest
-import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedThreadgateResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.*
 import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoCreateRecordRequest
 import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoDeleteRecordRequest
 import work.socialhub.kbsky.api.entity.share.Response
@@ -511,6 +470,21 @@ class _FeedResource(
                     .accept(MediaType.JSON)
                     .json(request.toMappedJson())
                     .postWithAuth(request.auth)
+            }
+        }
+    }
+
+    override fun getBookmarks(
+        request: FeedGetBookmarksRequest
+    ): Response<FeedGetBookmarksResponse> {
+
+        return proceed {
+            runBlocking {
+                HttpRequest()
+                    .url(xrpc(config, FeedGetBookmarks))
+                    .accept(MediaType.JSON)
+                    .queries(request.toMap())
+                    .getWithAuth(request.auth)
             }
         }
     }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsBookmarkItemUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsBookmarkItemUnion.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.model.app.bsky.feed
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.util.json.FeedDefsBookmarkPolymorphicSerializer
+
+/**
+ * @see FeedDefsNotFoundPost
+ * @see FeedDefsPostView
+ */
+@Serializable(with = FeedDefsBookmarkPolymorphicSerializer::class)
+interface FeedDefsBookmarkItemUnion {
+    @SerialName("\$type")
+    val type: String
+}
+
+val FeedDefsBookmarkItemUnion.asNotFoundPost get() = this as? FeedDefsNotFoundPost
+val FeedDefsBookmarkItemUnion.asPostView get() = this as? FeedDefsPostView

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsBookmarkView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsBookmarkView.kt
@@ -1,0 +1,11 @@
+package work.socialhub.kbsky.model.app.bsky.feed
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.com.atproto.repo.RepoStrongRef
+
+@Serializable
+data class FeedDefsBookmarkView(
+    val subject: RepoStrongRef,
+    val createdAt: String? = null,
+    val item: FeedDefsBookmarkItemUnion,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsNotFoundPost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsNotFoundPost.kt
@@ -10,7 +10,7 @@ data class FeedDefsNotFoundPost(
     override var type: String = TYPE,
     var uri: String? = null,
     var notFound: Boolean = true,
-) : FeedDefsThreadUnion() {
+) : FeedDefsThreadUnion(), FeedDefsBookmarkItemUnion {
     companion object {
         val TYPE = BlueskyTypes.FeedDefs + "#notFoundPost"
     }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
@@ -16,6 +16,7 @@ data class FeedDefsPostView(
     var replyCount: Int? = null,
     var repostCount: Int? = null,
     var likeCount: Int? = null,
+    var bookmarkCount: Int? = null,
     var quoteCount: Int? = null,
     var indexedAt: String? = null,
     var viewer: FeedDefsViewerState? = null,

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsPostView.kt
@@ -1,6 +1,8 @@
 package work.socialhub.kbsky.model.app.bsky.feed
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsProfileViewBasic
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedViewUnion
 import work.socialhub.kbsky.model.com.atproto.label.LabelDefsLabel
@@ -8,6 +10,8 @@ import work.socialhub.kbsky.model.share.RecordUnion
 
 @Serializable
 data class FeedDefsPostView(
+    @SerialName("\$type")
+    override var type: String = TYPE,
     var uri: String? = null,
     var cid: String? = null,
     var author: ActorDefsProfileViewBasic? = null,
@@ -22,4 +26,8 @@ data class FeedDefsPostView(
     var viewer: FeedDefsViewerState? = null,
     var labels: List<LabelDefsLabel>? = null,
     var threadgate: FeedDefsThreadgateView? = null,
-)
+) : FeedDefsBookmarkItemUnion {
+    companion object {
+        val TYPE = BlueskyTypes.FeedDefs + "#postView"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsViewerState.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 data class FeedDefsViewerState(
     var repost: String? = null,
     var like: String? = null,
+    var bookmarked: Boolean? = null,
     var replyDisabled: Boolean? = null,
     var embeddingDisabled: Boolean? = null,
     var pinned: Boolean? = null,

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/FeedDefsBookmarkPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/FeedDefsBookmarkPolymorphicSerializer.kt
@@ -1,0 +1,33 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsBookmarkItemUnion
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsNotFoundPost
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object FeedDefsBookmarkPolymorphicSerializer :
+    JsonContentPolymorphicSerializer<FeedDefsBookmarkItemUnion>(
+        FeedDefsBookmarkItemUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<FeedDefsBookmarkItemUnion> = when (val type = element.type()) {
+        FeedDefsPostView.TYPE -> FeedDefsPostView.serializer()
+        FeedDefsNotFoundPost.TYPE -> FeedDefsNotFoundPost.serializer()
+        // TODO FeedDefsBlockedPost support
+        else -> {
+            println("[Warning] Unknown Item type: $type (FeedDefsBookmarkItemUnion)")
+            Unknown.serializer()
+        }
+    }
+
+    @Serializable
+    class Unknown : FeedDefsBookmarkItemUnion {
+        override var type: String = "unknown"
+    }
+}


### PR DESCRIPTION
Support new Bookmark APIs

----

https://github.com/bluesky-social/atproto/commit/64100a75b31eae44f75ce440d7bed18e24f3ccbf で追加された新しいブックマーク用APIを追加しました。

各コミットメッセージの通りですが、
- 3de007f21a38983f2f3d4f34f0512661c4caf1c0 : bookmarkCount と bookmarked の追加
- f13e9919e44f7447c24b3ea550b3ddb4a1e52a3a : createBookmark の追加
- 5aabe72d5a75d3a2803d83084c309380b094f4ec : deleteBookmark の追加
- a2708985f2123223e4723c707bc358eba3787fcd : getBookmarks の追加

を行いました。

いずれも例によって ZonePane で利用済みです。