### PR TITLE
Review of PR #221 and addition of verification tests

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewRecord.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewRecord.kt
@@ -19,6 +19,11 @@ data class EmbedRecordViewRecord(
     var author: ActorDefsProfileViewBasic? = null,
     var value: RecordUnion? = null,
     var labels: List<LabelDefsLabel>? = null,
+    var replyCount: Int? = null,
+    var repostCount: Int? = null,
+    var likeCount: Int? = null,
+    var bookmarkCount: Int? = null,
+    var quoteCount: Int? = null,
     var embeds: List<EmbedViewUnion>? = null,
     var indexedAt: String? = null,
 ) : EmbedRecordViewUnion() {

--- a/core/src/commonTest/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewRecordTest.kt
+++ b/core/src/commonTest/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedRecordViewRecordTest.kt
@@ -1,0 +1,40 @@
+package work.socialhub.kbsky.model.app.bsky.embed
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EmbedRecordViewRecordTest {
+
+    @Test
+    fun testEmbedRecordViewRecordSerialization() {
+        val json = """
+            {
+                "uri": "at://did:plc:abc/app.bsky.feed.post/123",
+                "cid": "bafyreih",
+                "author": {
+                    "did": "did:plc:abc",
+                    "handle": "abc.bsky.social"
+                },
+                "value": {
+                    "text": "hello"
+                },
+                "replyCount": 10,
+                "repostCount": 20,
+                "likeCount": 30,
+                "bookmarkCount": 40,
+                "quoteCount": 50,
+                "indexedAt": "2023-10-01T00:00:00Z"
+            }
+        """.trimIndent()
+
+        val format = Json { ignoreUnknownKeys = true }
+        val record = format.decodeFromString<EmbedRecordViewRecord>(json)
+
+        assertEquals(10, record.replyCount)
+        assertEquals(20, record.repostCount)
+        assertEquals(30, record.likeCount)
+        assertEquals(40, record.bookmarkCount)
+        assertEquals(50, record.quoteCount)
+    }
+}


### PR DESCRIPTION
I reviewed PR #221 and added a unit test to verify the new engagement count fields in `EmbedRecordViewRecord`. The implementation correctly uses `replyCount` (fixing the typo in the PR title) and follows the project's style. The tests pass and the build is successful.

---
*PR created automatically by Jules for task [4184681032340432881](https://jules.google.com/task/4184681032340432881) started by @uakihir0*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended embedded record views to include engagement metrics: reply count, repost count, like count, bookmark count, and quote count. These fields are now available in the API response.

* **Tests**
  * Added test coverage for serialization and deserialization of the new engagement metrics fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->