### PR TITLE
Fix: Kotlin 2.3.20 で @JsExport インターフェースの suspend 関数がビルドエラーになる問題を修正

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
         // for test (kotlin/jvm)
         jvmTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.coroutines.test)
             implementation(libs.cryptography.jdk)
             implementation(libs.slf4j.simple)
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -41,10 +41,6 @@ kotlin {
     mingwX64()
     linuxX64()
 
-    compilerOptions {
-        freeCompilerArgs.add("-Xenable-suspend-function-exporting")
-    }
-
     sourceSets {
         all {
             languageSettings.apply {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/PLCDirectory.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/PLCDirectory.kt
@@ -9,11 +9,13 @@ import kotlin.js.JsExport
 @JsExport
 interface PLCDirectory {
 
+    @JsExport.Ignore
     suspend fun DIDDetails(did: String): Response<DIDDetails>
 
     @JsExport.Ignore
     fun DIDDetailsBlocking(did: String): Response<DIDDetails>
 
+    @JsExport.Ignore
     suspend fun DIDLogs(did: String): Response<List<DIDLog>>
 
     @JsExport.Ignore

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/ActorResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/ActorResource.kt
@@ -22,6 +22,7 @@ interface ActorResource {
     /**
      * Find actors matching search criteria.
      */
+    @JsExport.Ignore
     suspend fun searchActors(
         request: ActorSearchActorsRequest
     ): Response<ActorSearchActorsResponse>
@@ -34,6 +35,7 @@ interface ActorResource {
     /**
      * Find actor suggestions for a prefix search term.
      */
+    @JsExport.Ignore
     suspend fun searchActorsTypeahead(
         request: ActorSearchActorsTypeaheadRequest
     ): Response<ActorSearchActorsTypeaheadResponse>
@@ -46,6 +48,7 @@ interface ActorResource {
     /**
      * Get detailed profile view of an actor.
      */
+    @JsExport.Ignore
     suspend fun getProfile(
         request: ActorGetProfileRequest
     ): Response<ActorGetProfileResponse>
@@ -58,6 +61,7 @@ interface ActorResource {
     /**
      * Update the profile of the actor.
      */
+    @JsExport.Ignore
     suspend fun updateProfile(
         request: ActorUpdateProfileRequest
     ): Response<ActorUpdateProfileResponse>
@@ -70,6 +74,7 @@ interface ActorResource {
     /**
      * Get detailed profile views of multiple actors.
      */
+    @JsExport.Ignore
     suspend fun getProfiles(
         request: ActorGetProfilesRequest
     ): Response<ActorGetProfilesResponse>
@@ -82,6 +87,7 @@ interface ActorResource {
     /**
      * Get private preferences attached to the account.
      */
+    @JsExport.Ignore
     suspend fun getPreferences(
         request: ActorGetPreferencesRequest
     ): Response<ActorGetPreferencesResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
@@ -60,6 +60,7 @@ interface FeedResource {
     /**
      * A view of a user's feed.
      */
+    @JsExport.Ignore
     suspend fun getAuthorFeed(
         request: FeedGetAuthorFeedRequest
     ): Response<FeedGetAuthorFeedResponse>
@@ -72,6 +73,7 @@ interface FeedResource {
     /**
      *
      */
+    @JsExport.Ignore
     suspend fun getLikes(
         request: FeedGetLikesRequest
     ): Response<FeedGetLikesResponse>
@@ -84,6 +86,7 @@ interface FeedResource {
     /**
      *
      */
+    @JsExport.Ignore
     suspend fun getPostThread(
         request: FeedGetPostThreadRequest
     ): Response<FeedGetPostThreadResponse>
@@ -96,6 +99,7 @@ interface FeedResource {
     /**
      * A view of an actor's feed.
      */
+    @JsExport.Ignore
     suspend fun getPosts(
         request: FeedGetPostsRequest
     ): Response<FeedGetPostsResponse>
@@ -108,6 +112,7 @@ interface FeedResource {
     /**
      * Get a list of quotes for a given post.
      */
+    @JsExport.Ignore
     suspend fun getQuotes(
         request: FeedGetQuotesRequest
     ): Response<FeedGetQuotesResponse>
@@ -120,6 +125,7 @@ interface FeedResource {
     /**
      * Get a list of reposts for a given post.
      */
+    @JsExport.Ignore
     suspend fun getRepostedBy(
         request: FeedGetRepostedByRequest
     ): Response<FeedGetRepostedByResponse>
@@ -132,6 +138,7 @@ interface FeedResource {
     /**
      * A view of the user's home timeline.
      */
+    @JsExport.Ignore
     suspend fun getTimeline(
         request: FeedGetTimelineRequest
     ): Response<FeedGetTimelineResponse>
@@ -144,6 +151,7 @@ interface FeedResource {
     /**
      * Compose and hydrate a feed from a user's selected feed generator.
      */
+    @JsExport.Ignore
     suspend fun getFeed(
         request: FeedGetFeedRequest
     ): Response<FeedGetFeedResponse>
@@ -156,6 +164,7 @@ interface FeedResource {
     /**
      * Get a feed of recent posts from a list (posts and reposts from any actors on the list). Does not require auth.
      */
+    @JsExport.Ignore
     suspend fun getListFeed(
         request: FeedGetListFeedRequest
     ): Response<FeedGetListFeedResponse>
@@ -168,6 +177,7 @@ interface FeedResource {
     /**
      * Retrieve a list of feeds created by a given actor
      */
+    @JsExport.Ignore
     suspend fun getActorFeeds(
         request: FeedGetActorFeedsRequest
     ): Response<FeedGetActorFeedsResponse>
@@ -180,6 +190,7 @@ interface FeedResource {
     /**
      * Get a list of posts liked by an actor.
      */
+    @JsExport.Ignore
     suspend fun getActorLikes(
         request: FeedGetActorLikesRequest
     ): Response<FeedGetActorLikesResponse>
@@ -192,6 +203,7 @@ interface FeedResource {
     /**
      * Find posts matching search criteria.
      */
+    @JsExport.Ignore
     suspend fun searchPosts(
         request: FeedSearchPostsRequest
     ): Response<FeedSearchPostsResponse>
@@ -204,6 +216,7 @@ interface FeedResource {
     /**
      * Get information about a specific feed offered by a feed generator, such as its online status.
      */
+    @JsExport.Ignore
     suspend fun getFeedGenerator(
         request: FeedGetFeedGeneratorRequest
     ): Response<FeedGetFeedGeneratorResponse>
@@ -216,6 +229,7 @@ interface FeedResource {
     /**
      * Get information about a list of feed generators.
      */
+    @JsExport.Ignore
     suspend fun getFeedGenerators(
         request: FeedGetFeedGeneratorsRequest
     ): Response<FeedGetFeedGeneratorsResponse>
@@ -229,6 +243,7 @@ interface FeedResource {
      * Like feed operation.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun like(
         request: FeedLikeRequest
     ): Response<FeedLikeResponse>
@@ -242,6 +257,7 @@ interface FeedResource {
      * Delete Like operation.
      * (ATProtocol/Repo deleteRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun deleteLike(
         request: FeedDeleteLikeRequest
     ): ResponseUnit
@@ -255,6 +271,7 @@ interface FeedResource {
      * Post feed operation.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun post(
         request: FeedPostRequest
     ): Response<FeedPostResponse>
@@ -268,6 +285,7 @@ interface FeedResource {
      * Delete Feed operation.
      * (ATProtocol/Repo deleteRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun deletePost(
         request: FeedDeletePostRequest
     ): ResponseUnit
@@ -281,6 +299,7 @@ interface FeedResource {
      * Repost feed operation.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun repost(
         request: FeedRepostRequest
     ): Response<FeedRepostResponse>
@@ -294,6 +313,7 @@ interface FeedResource {
      * Delete Repost operation.
      * (ATProtocol/Repo deleteRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun deleteRepost(
         request: FeedDeleteRepostRequest
     ): ResponseUnit
@@ -307,6 +327,7 @@ interface FeedResource {
      * Threadgate feed operation.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun threadgate(
         request: FeedThreadgateRequest
     ): Response<FeedThreadgateResponse>
@@ -320,6 +341,7 @@ interface FeedResource {
      * Record defining interaction rules for a post.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun postgate(
         request: FeedPostgateRequest
     ): Response<FeedPostgateResponse>
@@ -332,6 +354,7 @@ interface FeedResource {
     /**
      * Creates a private bookmark for the specified record.
      */
+    @JsExport.Ignore
     suspend fun createBookmark(
         request: FeedCreateBookmarkRequest
     ): ResponseUnit
@@ -344,6 +367,7 @@ interface FeedResource {
     /**
      * Deletes a private bookmark for the specified record.
      */
+    @JsExport.Ignore
     suspend fun deleteBookmark(
         request: FeedDeleteBookmarkRequest
     ): ResponseUnit
@@ -356,6 +380,7 @@ interface FeedResource {
     /**
      * Gets views of records bookmarked by the authenticated user.
      */
+    @JsExport.Ignore
     suspend fun getBookmarks(
         request: FeedGetBookmarksRequest
     ): Response<FeedGetBookmarksResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/GraphResource.kt
@@ -50,6 +50,7 @@ interface GraphResource {
      * Follow operation.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun follow(
         request: GraphFollowRequest
     ): Response<GraphFollowResponse>
@@ -63,6 +64,7 @@ interface GraphResource {
      * Delete Follow operation.
      * (ATProtocol/Repo deleteRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun deleteFollow(
         request: GraphDeleteFollowRequest
     ): ResponseUnit
@@ -75,6 +77,7 @@ interface GraphResource {
     /**
      * Who is following an actor?
      */
+    @JsExport.Ignore
     suspend fun getFollowers(
         request: GraphGetFollowersRequest
     ): Response<GraphGetFollowersResponse>
@@ -87,6 +90,7 @@ interface GraphResource {
     /**
      * Who is an actor following?
      */
+    @JsExport.Ignore
     suspend fun getFollows(
         request: GraphGetFollowsRequest
     ): Response<GraphGetFollowsResponse>
@@ -99,6 +103,7 @@ interface GraphResource {
     /**
      * Enumerates accounts which follow a specified account (actor) and are followed by the viewer.
      */
+    @JsExport.Ignore
     suspend fun getKnownFollowers(
         request: GraphGetKnownFollowersRequest
     ): Response<GraphGetKnownFollowersResponse>
@@ -111,6 +116,7 @@ interface GraphResource {
     /**
      * Who does the viewer mute?
      */
+    @JsExport.Ignore
     suspend fun getMutes(
         request: GraphGetMutesRequest
     ): Response<GraphGetMutesResponse>
@@ -123,6 +129,7 @@ interface GraphResource {
     /**
      * Mute an actor by did or handle.
      */
+    @JsExport.Ignore
     suspend fun muteActor(
         request: GraphMuteActorRequest
     ): ResponseUnit
@@ -135,6 +142,7 @@ interface GraphResource {
     /**
      * Unmute an actor by did or handle.
      */
+    @JsExport.Ignore
     suspend fun unmuteActor(
         request: GraphUnmuteActorRequest
     ): ResponseUnit
@@ -148,6 +156,7 @@ interface GraphResource {
      * Block operation.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun block(
         request: GraphBlockRequest
     ): Response<GraphBlockResponse>
@@ -161,6 +170,7 @@ interface GraphResource {
      * Delete Block operation.
      * (ATProtocol/Repo deleteRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun deleteBlock(
         request: GraphDeleteBlockRequest
     ): ResponseUnit
@@ -173,6 +183,7 @@ interface GraphResource {
     /**
      * Who does the viewer mute?
      */
+    @JsExport.Ignore
     suspend fun getBlocks(
         request: GraphGetBlocksRequest
     ): Response<GraphGetBlocksResponse>
@@ -186,6 +197,7 @@ interface GraphResource {
      * Create a list.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun createList(
         request: GraphCreateListRequest
     ): Response<GraphCreateListResponse>
@@ -199,6 +211,7 @@ interface GraphResource {
      * Edit a list.
      * (ATProtocol/Repo getRecord and putRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun editList(
         request: GraphEditListRequest
     ): Response<GraphEditListResponse>
@@ -212,6 +225,7 @@ interface GraphResource {
      * Delete a list.
      * (ATProtocol/Repo deleteRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun deleteList(
         request: GraphDeleteListRequest
     ): ResponseUnit
@@ -224,6 +238,7 @@ interface GraphResource {
     /**
      * Gets a 'view' (with additional context) of a specified list.
      */
+    @JsExport.Ignore
     suspend fun getList(
         request: GraphGetListRequest
     ): Response<GraphGetListResponse>
@@ -236,6 +251,7 @@ interface GraphResource {
     /**
      * Enumerates the lists created by a specified account (actor).
      */
+    @JsExport.Ignore
     suspend fun getLists(
         request: GraphGetListsRequest
     ): Response<GraphGetListsResponse>
@@ -249,6 +265,7 @@ interface GraphResource {
      * Add a user to a list.
      * (ATProtocol/Repo createRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun addUserToList(
         request: GraphAddUserToListRequest
     ): Response<GraphAddUserToListResponse>
@@ -262,6 +279,7 @@ interface GraphResource {
      * Remove a user from a list.
      * (ATProtocol/Repo deleteRecord wrapper)
      */
+    @JsExport.Ignore
     suspend fun removeUserFromList(
         request: GraphRemoveUserFromListRequest
     ): ResponseUnit
@@ -274,6 +292,7 @@ interface GraphResource {
     /**
      * Gets a view of a starter pack.
      */
+    @JsExport.Ignore
     suspend fun getStarterPack(
         request: GraphGetStarterPackRequest
     ): Response<GraphGetStarterPackResponse>
@@ -286,6 +305,7 @@ interface GraphResource {
     /**
      * Gets a view of a starter pack.
      */
+    @JsExport.Ignore
     suspend fun getStarterPacks(
         request: GraphGetStarterPacksRequest
     ): Response<GraphGetStarterPacksResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/LabelerResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/LabelerResource.kt
@@ -16,6 +16,7 @@ interface LabelerResource {
     /**
      * Get information about a list of labeler services.
      */
+    @JsExport.Ignore
     suspend fun getServices(
         request: LabelerGetServicesRequest
     ): Response<LabelerGetServicesResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/NotificationResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/NotificationResource.kt
@@ -21,6 +21,7 @@ interface NotificationResource {
     /**
      * Get the number of unread notifications.
      */
+    @JsExport.Ignore
     suspend fun getUnreadCount(
         request: NotificationGetUnreadCountRequest
     ): Response<NotificationGetUnreadCountResponse>
@@ -33,6 +34,7 @@ interface NotificationResource {
     /**
      * List notifications.
      */
+    @JsExport.Ignore
     suspend fun listNotifications(
         request: NotificationListNotificationsRequest
     ): Response<NotificationListNotificationsResponse>
@@ -45,6 +47,7 @@ interface NotificationResource {
     /**
      * Notify server that the user has seen notifications.
      */
+    @JsExport.Ignore
     suspend fun updateSeen(
         request: NotificationUpdateSeenRequest
     ): ResponseUnit

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/UnspeccedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/UnspeccedResource.kt
@@ -13,6 +13,7 @@ interface UnspeccedResource {
     /**
      * DEPRECATED: will be removed soon. Use a feed generator alternative.
      */
+    @JsExport.Ignore
     suspend fun getPopular(
         request: UnspeccedGetPopularRequest
     ): Response<UnspeccedGetPopularResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/VideoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/VideoResource.kt
@@ -19,6 +19,7 @@ interface VideoResource {
     /**
      * Get status details for a video processing job.
      */
+    @JsExport.Ignore
     suspend fun getJobStatus(
         request: VideoGetJobStatusRequest
     ): Response<VideoGetJobStatusResponse>
@@ -31,6 +32,7 @@ interface VideoResource {
     /**
      * Get video upload limits for the authenticated user.
      */
+    @JsExport.Ignore
     suspend fun getUploadLimits(
         request: VideoGetUploadLimitsRequest
     ): Response<VideoGetUploadLimitsResponse>
@@ -43,6 +45,7 @@ interface VideoResource {
     /**
      * Upload a video to be processed then stored on the PDS.
      */
+    @JsExport.Ignore
     suspend fun uploadVideo(
         request: VideoUploadVideoRequest
     ): Response<VideoUploadVideoResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/ConvoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/ConvoResource.kt
@@ -41,6 +41,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.getConvo
      */
+    @JsExport.Ignore
     suspend fun getConvo(
         request: ConvoGetConvoRequest
     ): Response<ConvoGetConvoResponse>
@@ -53,6 +54,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.getConvoForMembers
      */
+    @JsExport.Ignore
     suspend fun getConvoForMembers(
         request: ConvoGetConvoForMembersRequest
     ): Response<ConvoGetConvoForMembersResponse>
@@ -65,6 +67,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.getLog
      */
+    @JsExport.Ignore
     suspend fun getLog(
         request: ConvoGetLogRequest
     ): Response<ConvoGetLogResponse>
@@ -77,6 +80,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.getMessages
      */
+    @JsExport.Ignore
     suspend fun getMessages(
         request: ConvoGetMessagesRequest
     ): Response<ConvoGetMessagesResponse>
@@ -89,6 +93,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.listConvos
      */
+    @JsExport.Ignore
     suspend fun getListConvos(
         request: ConvoGetListConvosRequest
     ): Response<ConvoGetListConvosResponse>
@@ -101,6 +106,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.sendMessage
      */
+    @JsExport.Ignore
     suspend fun sendMessage(
         request: ConvoSendMessageRequest
     ): Response<ConvoSendMessageResponse>
@@ -113,6 +119,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.updateRead
      */
+    @JsExport.Ignore
     suspend fun updateRead(
         request: ConvoUpdateReadRequest
     ): Response<ConvoUpdateReadResponse>
@@ -125,6 +132,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.muteConvo
      */
+    @JsExport.Ignore
     suspend fun muteConvo(
         request: ConvoMuteConvoRequest
     ): Response<ConvoMuteConvoResponse>
@@ -137,6 +145,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.unmuteConvo
      */
+    @JsExport.Ignore
     suspend fun unmuteConvo(
         request: ConvoUnmuteConvoRequest
     ): Response<ConvoUnmuteConvoResponse>
@@ -149,6 +158,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.deleteMessageForSelf
      */
+    @JsExport.Ignore
     suspend fun deleteMessageForSelf(
         request: ConvoDeleteMessageForSelfRequest
     ): Response<ConvoDeleteMessageForSelfResponse>
@@ -161,6 +171,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.leaveConvo
      */
+    @JsExport.Ignore
     suspend fun leaveConvo(
         request: ConvoLeaveConvoRequest
     ): Response<ConvoLeaveConvoResponse>
@@ -173,6 +184,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.addReaction
      */
+    @JsExport.Ignore
     suspend fun addReaction(
         request: ConvoAddReactionRequest
     ): Response<ConvoAddReactionResponse>
@@ -185,6 +197,7 @@ interface ConvoResource {
     /**
      * chat.bsky.convo.removeReaction
      */
+    @JsExport.Ignore
     suspend fun removeReaction(
         request: ConvoRemoveReactionRequest
     ): Response<ConvoRemoveReactionResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/IdentityResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/IdentityResource.kt
@@ -16,6 +16,7 @@ interface IdentityResource {
     /**
      * Provides the DID of a repo.
      */
+    @JsExport.Ignore
     suspend fun resolveHandle(
         request: IdentityResolveHandleRequest
     ): Response<IdentityResolveHandleResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/ModerationResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/ModerationResource.kt
@@ -16,6 +16,7 @@ interface ModerationResource {
     /**
      * レポートを作成する
      */
+    @JsExport.Ignore
     suspend fun createReport(
         request: ModerationCreateReportRequest
     ): Response<ModerationCreateReportResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/RepoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/RepoResource.kt
@@ -34,6 +34,7 @@ interface RepoResource {
     /**
      * Create a new record.
      */
+    @JsExport.Ignore
     suspend fun createRecord(
         request: RepoCreateRecordRequest
     ): Response<RepoCreateRecordResponse>
@@ -46,6 +47,7 @@ interface RepoResource {
     /**
      * Delete a record, or ensure it doesn't exist.
      */
+    @JsExport.Ignore
     suspend fun deleteRecord(
         request: RepoDeleteRecordRequest
     ): ResponseUnit
@@ -58,6 +60,7 @@ interface RepoResource {
     /**
      * Get information about an account and repository, including the list of collections. Does not require auth.
      */
+    @JsExport.Ignore
     suspend fun describeRepo(
         request: RepoDescribeRepoRequest
     ): Response<RepoDescribeRepoResponse>
@@ -70,6 +73,7 @@ interface RepoResource {
     /**
      * Get a record.
      */
+    @JsExport.Ignore
     suspend fun getRecord(
         request: RepoGetRecordRequest
     ): Response<RepoGetRecordResponse>
@@ -82,6 +86,7 @@ interface RepoResource {
     /**
      * List a range of records in a collection.
      */
+    @JsExport.Ignore
     suspend fun listRecords(
         request: RepoListRecordsRequest
     ): Response<RepoListRecordsResponse>
@@ -94,6 +99,7 @@ interface RepoResource {
     /**
      * Write a record, creating or updating it as needed.
      */
+    @JsExport.Ignore
     suspend fun putRecord(
         request: RepoPutRecordRequest
     ): Response<RepoPutRecordResponse>
@@ -106,6 +112,7 @@ interface RepoResource {
     /**
      * Upload a new blob to be added to repo in a later request.
      */
+    @JsExport.Ignore
     suspend fun uploadBlob(
         request: RepoUploadBlobRequest
     ): Response<RepoUploadBlobResponse>

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/ServerResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/com/atproto/ServerResource.kt
@@ -34,6 +34,7 @@ interface ServerResource {
     /**
      * Create an authentication session.
      */
+    @JsExport.Ignore
     suspend fun createSession(
         request: ServerCreateSessionRequest
     ): Response<ServerCreateSessionResponse>
@@ -52,6 +53,7 @@ interface ServerResource {
     /**
      * Delete the current session.
      */
+    @JsExport.Ignore
     suspend fun deleteSession(
         request: AuthRequest
     ): ResponseUnit
@@ -71,6 +73,7 @@ interface ServerResource {
      *
      * [Reference](https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/server/getServiceAuth.json)
      */
+    @JsExport.Ignore
     suspend fun getServiceAuth(
         request: ServerGetServiceAuthRequest
     ): Response<ServerGetServiceAuthResponse>
@@ -84,6 +87,7 @@ interface ServerResource {
      * TODO:
      * Get information about the current session.
      */
+    @JsExport.Ignore
     suspend fun getSession(
         request: AuthRequest
     ): Response<ServerGetSessionResponse>
@@ -96,6 +100,7 @@ interface ServerResource {
     /**
      * Refresh an authentication session.
      */
+    @JsExport.Ignore
     suspend fun refreshSession(
         request: AuthRequest
     ): Response<ServerRefreshSessionResponse>

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -41,10 +41,6 @@ kotlin {
     mingwX64()
     // linuxX64()
 
-    compilerOptions {
-        freeCompilerArgs.add("-Xenable-suspend-function-exporting")
-    }
-
     sourceSets {
         all {
             languageSettings.apply {

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/com/atproto/SyncStreamClient.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/com/atproto/SyncStreamClient.kt
@@ -48,6 +48,7 @@ class SyncStreamClient(
         }
     }
 
+    @JsExport.Ignore
     suspend fun open() {
         client.open()
     }


### PR DESCRIPTION
## Summary
- Kotlin 2.3.20 で `:core:compileCommonMainKotlinMetadata` がコンパイルエラーになる問題を修正
- `@JsExport` 配下の `suspend fun` に `@JsExport.Ignore` を付与
- 廃止された `-Xenable-suspend-function-exporting` フラグを削除
- `auth` モジュールの `runTest` 未解決を解消

## Background
Kotlin 2.3.20 で `-Xenable-suspend-function-exporting` コンパイラフラグがサポートされなくなり、`@JsExport` が付いたインターフェース/クラス内の `suspend fun` が以下のエラーになるようになりました。

```
e: Declaration of such kind (suspend function) cannot be exported to JavaScript.
```

各リソースインターフェースには既に `*Blocking` 関数が `@JsExport.Ignore` 付きで用意されているため、`suspend fun` 側にも同じく `@JsExport.Ignore` を付与する形で対応します。JS から呼び出す側は `*Blocking` を利用する設計のままです。

## Changes
- core の Resource 系インターフェース 12ファイル の `suspend fun` に `@JsExport.Ignore` を追加（計86箇所）
  - `ActorResource.kt`, `FeedResource.kt`, `GraphResource.kt`, `LabelerResource.kt`, `NotificationResource.kt`, `UnspeccedResource.kt`, `VideoResource.kt`, `ConvoResource.kt`, `IdentityResource.kt`, `ModerationResource.kt`, `RepoResource.kt`, `ServerResource.kt`
- `PLCDirectory.kt` の `suspend fun` 2件に `@JsExport.Ignore` を追加
- `stream/SyncStreamClient.kt` の `suspend fun open()` に `@JsExport.Ignore` を追加
- `core/build.gradle.kts`, `stream/build.gradle.kts` からサポート外となった `-Xenable-suspend-function-exporting` を削除
- `auth/build.gradle.kts` の jvmTest 依存に `libs.coroutines.test` を追加（`runTest` の未解決参照を解消）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added test utilities for asynchronous testing framework.
  * Simplified build configuration by removing compiler settings.
  * Updated JavaScript export behavior across multiple API operations to use blocking variants instead of suspend functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->