### PR TITLE
Fix: WellKnown OAuth discovery で末尾スラッシュの二重結合バグを修正

### DIFF
--- a/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/WellKnownResourceImpl.kt
+++ b/auth/src/commonMain/kotlin/work/socialhub/kbsky/auth/internal/WellKnownResourceImpl.kt
@@ -19,7 +19,9 @@ class WellKnownResourceImpl(
         return toBlocking {
             proceed<WellKnownOAuthProtectedResourceResponse> {
                 HttpRequest()
-                    .url("${config.pdsServer}/.well-known/oauth-protected-resource")
+                    // Trim trailing slash before concatenation
+                    // (e.g. prevent "https://example.com/" + "/.well-known/..." → "//.well-known/...")
+                    .url("${config.pdsServer.trimEnd('/')}/.well-known/oauth-protected-resource")
                     .accept(MediaType.JSON)
                     .get()
             }.also {
@@ -37,7 +39,10 @@ class WellKnownResourceImpl(
         return toBlocking {
             proceed<WellKnownOAuthAuthorizationServerResponse> {
                 HttpRequest()
-                    .url("${config.authorizationServer}/.well-known/oauth-authorization-server")
+                    // Trim trailing slash before concatenation
+                    // (oAuthProtectedResource appends a trailing "/" to authorizationServer in its
+                    //  response handling, so without trimEnd here a "//.well-known/..." double slash occurs)
+                    .url("${config.authorizationServer.trimEnd('/')}/.well-known/oauth-authorization-server")
                     .accept(MediaType.JSON)
                     .get()
             }.also {


### PR DESCRIPTION
## Summary
- `WellKnownResourceImpl` の URL 組み立てで `//.well-known/...` のような二重スラッシュが発生するバグを修正
- `oAuthProtectedResource()` と `oAuthAuthorizationServer()` の 2 箇所で `trimEnd('/')` を追加

## Background
カスタム PDS（例: pds.pckt.cafe）に対して AT Protocol OAuth フローでログインを試みると以下のエラーが発生していました:

```
Cannot GET //.well-known/oauth-authorization-server
```

原因は `oAuthProtectedResource()` のレスポンス処理で `authorizationServers[0]` の末尾に `/` を必ず付与した上で `config.authorizationServer` にセットしているため、後続の `oAuthAuthorizationServer()` で `${config.authorizationServer}/.well-known/...` と結合した時に `//` の二重スラッシュが発生していました。

bsky.social では `/\` を `/` に正規化していたためか発症しませんでしたが、Express 系のサーバを使う他 PDS（pckt 等）では `//` のパスが 404 になります。

## Changes
- `WellKnownResourceImpl.kt` の `oAuthProtectedResource()`: `${config.pdsServer}` → `${config.pdsServer.trimEnd('/')}`
- `WellKnownResourceImpl.kt` の `oAuthAuthorizationServer()`: `${config.authorizationServer}` → `${config.authorizationServer.trimEnd('/')}`

## Test plan
- [x] bsky.social での OAuth ログインが従来通り動作すること
- [x] カスタム PDS（pds.pckt.cafe）での OAuth wellKnown discovery が `//` 二重スラッシュにならず正しく動作すること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the authentication flow where base URLs could be incorrectly formatted with double slashes when constructing requests. This resolves potential problems with OAuth-related operations and ensures proper communication with authorization services. The improvement enhances stability and compatibility across different authentication configurations and service integrations while ensuring reliable request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->