### PR TITLE
Replace deprecated -Xenable-suspend-function-exporting with -XXLangua…

### DIFF
--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
     // linuxX64()
 
     compilerOptions {
-        freeCompilerArgs.add("-Xenable-suspend-function-exporting")
+        freeCompilerArgs.add("-XXLanguage:+JsAllowExportingSuspendFunctions")
     }
 
     sourceSets {


### PR DESCRIPTION
…ge:+JsAllowExportingSuspendFunctions in stream module

The old compiler flag was removed in Kotlin 2.3.20, causing compileCommonMainKotlinMetadata to fail. This change uses the new language feature flag to restore @JsExport support for suspend functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kotlin build compiler settings to improve suspend function exporting and build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->