### PR TITLE
Add getSuggestedFeeds and getPopularFeedGenerators APIs

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -87,6 +87,7 @@ object BlueskyTypes {
 
     // Unspecced
     const val UnspeccedGetPopular = "app.bsky.unspecced.getPopular"
+    const val UnspeccedGetPopularFeedGenerators = "app.bsky.unspecced.getPopularFeedGenerators"
 
     // Video
     const val VideoGetJobStatus = "app.bsky.video.getJobStatus"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -46,6 +46,7 @@ object BlueskyTypes {
     const val FeedGetFeedSearchPosts = "app.bsky.feed.searchPosts"
     const val FeedGetFeedGenerator = "app.bsky.feed.getFeedGenerator"
     const val FeedGetFeedGenerators = "app.bsky.feed.getFeedGenerators"
+    const val FeedGetSuggestedFeeds = "app.bsky.feed.getSuggestedFeeds"
     const val FeedCreateBookmark = "app.bsky.bookmark.createBookmark"
     const val FeedDeleteBookmark = "app.bsky.bookmark.deleteBookmark"
     const val FeedGetBookmarks = "app.bsky.bookmark.getBookmarks"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
@@ -32,6 +32,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetSuggestedFeedsRequest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetSuggestedFeedsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedLikeRequest
@@ -224,6 +226,19 @@ interface FeedResource {
     fun getFeedGeneratorsBlocking(
         request: FeedGetFeedGeneratorsRequest
     ): Response<FeedGetFeedGeneratorsResponse>
+
+    /**
+     * Get a list of suggested feeds (feed generators) for the requesting account.
+     */
+    @JsExport.Ignore
+    suspend fun getSuggestedFeeds(
+        request: FeedGetSuggestedFeedsRequest
+    ): Response<FeedGetSuggestedFeedsResponse>
+
+    @JsExport.Ignore
+    fun getSuggestedFeedsBlocking(
+        request: FeedGetSuggestedFeedsRequest
+    ): Response<FeedGetSuggestedFeedsResponse>
 
     /**
      * Like feed operation.

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/UnspeccedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/UnspeccedResource.kt
@@ -1,6 +1,8 @@
 package work.socialhub.kbsky.api.app.bsky
 
 
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFeedGeneratorsRequest
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFeedGeneratorsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularRequest
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularResponse
 import work.socialhub.kbsky.api.entity.share.Response
@@ -21,4 +23,17 @@ interface UnspeccedResource {
     fun getPopularBlocking(
         request: UnspeccedGetPopularRequest
     ): Response<UnspeccedGetPopularResponse>
+
+    /**
+     * An unspecced view of globally popular feed generators.
+     */
+    @JsExport.Ignore
+    suspend fun getPopularFeedGenerators(
+        request: UnspeccedGetPopularFeedGeneratorsRequest
+    ): Response<UnspeccedGetPopularFeedGeneratorsResponse>
+
+    @JsExport.Ignore
+    fun getPopularFeedGeneratorsBlocking(
+        request: UnspeccedGetPopularFeedGeneratorsRequest
+    ): Response<UnspeccedGetPopularFeedGeneratorsResponse>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetSuggestedFeedsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetSuggestedFeedsRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class FeedGetSuggestedFeedsRequest(
+    override val auth: AuthProvider,
+    var limit: Int? = null,
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetSuggestedFeedsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedGetSuggestedFeedsResponse.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsGeneratorView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class FeedGetSuggestedFeedsResponse(
+    var cursor: String? = null,
+    var feeds: List<FeedDefsGeneratorView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularFeedGeneratorsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularFeedGeneratorsRequest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.api.entity.app.bsky.unspecced
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class UnspeccedGetPopularFeedGeneratorsRequest(
+    override val auth: AuthProvider,
+    var limit: Int? = null,
+    var cursor: String? = null,
+    var query: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+            it.addParam("query", query)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularFeedGeneratorsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPopularFeedGeneratorsResponse.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.api.entity.app.bsky.unspecced
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsGeneratorView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class UnspeccedGetPopularFeedGeneratorsResponse(
+    var cursor: String? = null,
+    var feeds: List<FeedDefsGeneratorView> = emptyList(),
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/FeedResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/FeedResourceImpl.kt
@@ -19,6 +19,7 @@ import work.socialhub.kbsky.BlueskyTypes.FeedGetPostThread
 import work.socialhub.kbsky.BlueskyTypes.FeedGetPosts
 import work.socialhub.kbsky.BlueskyTypes.FeedGetQuotes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetRepostedBy
+import work.socialhub.kbsky.BlueskyTypes.FeedGetSuggestedFeeds
 import work.socialhub.kbsky.BlueskyTypes.FeedGetTimeline
 import work.socialhub.kbsky.BlueskyTypes.FeedLike
 import work.socialhub.kbsky.BlueskyTypes.FeedPost
@@ -57,6 +58,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetQuotesResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetRepostedByResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetSuggestedFeedsRequest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetSuggestedFeedsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedGetTimelineResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedLikeRequest
@@ -388,6 +391,27 @@ class FeedResourceImpl(
     ): Response<FeedGetFeedGeneratorsResponse> {
         return toBlocking {
             getFeedGenerators(request)
+        }
+    }
+
+    override suspend fun getSuggestedFeeds(
+        request: FeedGetSuggestedFeedsRequest
+    ): Response<FeedGetSuggestedFeedsResponse> {
+
+        return proceed {
+            httpRequest(config)
+                .url(xrpc(config, FeedGetSuggestedFeeds))
+                .accept(MediaType.JSON)
+                .queries(request.toMap())
+                .getWithAuth(request.auth)
+        }
+    }
+
+    override fun getSuggestedFeedsBlocking(
+        request: FeedGetSuggestedFeedsRequest
+    ): Response<FeedGetSuggestedFeedsResponse> {
+        return toBlocking {
+            getSuggestedFeeds(request)
         }
     }
 

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/UnspeccedResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/UnspeccedResourceImpl.kt
@@ -2,7 +2,10 @@ package work.socialhub.kbsky.internal.app.bsky
 
 import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.BlueskyTypes.UnspeccedGetPopular
+import work.socialhub.kbsky.BlueskyTypes.UnspeccedGetPopularFeedGenerators
 import work.socialhub.kbsky.api.app.bsky.UnspeccedResource
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFeedGeneratorsRequest
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFeedGeneratorsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularRequest
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularResponse
 import work.socialhub.kbsky.api.entity.share.Response
@@ -33,4 +36,21 @@ class UnspeccedResourceImpl(
     override fun getPopularBlocking(
         request: UnspeccedGetPopularRequest
     ): Response<UnspeccedGetPopularResponse> = toBlocking { getPopular(request) }
+
+    override suspend fun getPopularFeedGenerators(
+        request: UnspeccedGetPopularFeedGeneratorsRequest
+    ): Response<UnspeccedGetPopularFeedGeneratorsResponse> {
+
+        return proceed {
+            httpRequest(config)
+                .url(xrpc(config, UnspeccedGetPopularFeedGenerators))
+                .accept(MediaType.JSON)
+                .queries(request.toMap())
+                .getWithAuth(request.auth)
+        }
+    }
+
+    override fun getPopularFeedGeneratorsBlocking(
+        request: UnspeccedGetPopularFeedGeneratorsRequest
+    ): Response<UnspeccedGetPopularFeedGeneratorsResponse> = toBlocking { getPopularFeedGenerators(request) }
 }


### PR DESCRIPTION
## Summary
- Add `app.bsky.feed.getSuggestedFeeds` (suggested feeds for the requesting account)
- Add `app.bsky.unspecced.getPopularFeedGenerators` (globally popular feed generators)

## Background
Two of the primary endpoints for discovering feed generators (custom feeds) were not yet implemented. These additions let clients fetch lists of suggested feeds and popular feeds.

## Changes
- `BlueskyTypes.kt`: Add NSID constants `FeedGetSuggestedFeeds` / `UnspeccedGetPopularFeedGenerators`
- `FeedResource.kt` / `FeedResourceImpl.kt`: Add `getSuggestedFeeds` / `getSuggestedFeedsBlocking`
- `UnspeccedResource.kt` / `UnspeccedResourceImpl.kt`: Add `getPopularFeedGenerators` / `getPopularFeedGeneratorsBlocking`
- Add `FeedGetSuggestedFeedsRequest` / `FeedGetSuggestedFeedsResponse` (`limit` / `cursor`; response is `cursor` + `feeds: List<FeedDefsGeneratorView>`)
- Add `UnspeccedGetPopularFeedGeneratorsRequest` / `UnspeccedGetPopularFeedGeneratorsResponse` (`limit` / `cursor` / `query`; response is `cursor` + `feeds: List<FeedDefsGeneratorView>`)

## Test plan
- [x] `./gradlew :core:compileKotlinJvm` compiles without errors
- [x] `getSuggestedFeeds` returns suggested feeds for a real account
- [x] `getPopularFeedGenerators` returns popular feed generators (including filtering when `query` is specified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving suggested feeds through new API methods with pagination and cursor support
  * Added support for retrieving globally popular feed generators with optional search, pagination, and limit controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uakihir0/kbsky/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->