### PR TITLE
ci: add concurrency to CI workflows

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,4 +1,7 @@
 name: Make Npm Package
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on: [push]
 
 jobs:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,7 +1,7 @@
 name: Make Npm Package
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 on: [push]
 
 jobs:

--- a/.github/workflows/pods.yml
+++ b/.github/workflows/pods.yml
@@ -1,4 +1,7 @@
 name: Make XCFramework
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on: [push]
 
 jobs:

--- a/.github/workflows/pods.yml
+++ b/.github/workflows/pods.yml
@@ -1,7 +1,7 @@
 name: Make XCFramework
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 on: [push]
 
 jobs:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -1,4 +1,7 @@
 name: Publish SNAPSHOT Package
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -1,7 +1,7 @@
 name: Publish SNAPSHOT Package
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 on:
   push:
     branches:

--- a/.github/workflows/swiftpackage.yml
+++ b/.github/workflows/swiftpackage.yml
@@ -1,4 +1,7 @@
 name: Make SwiftPackage
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on: [push]
 
 jobs:

--- a/.github/workflows/swiftpackage.yml
+++ b/.github/workflows/swiftpackage.yml
@@ -1,7 +1,7 @@
 name: Make SwiftPackage
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 on: [push]
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to implement concurrency control, preventing redundant concurrent builds across multiple pipeline configurations. In-progress jobs are automatically canceled when new runs are triggered for the same branch or reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->