### PR TITLE
feat: send wantedDids via SubscriberOptionsUpdate when URL would be t…

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/DeferredOptionsUpdate.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/DeferredOptionsUpdate.kt
@@ -1,0 +1,7 @@
+package work.socialhub.kbsky.stream.entity.app.bsky
+
+data class DeferredOptionsUpdate(
+    val wantedCollections: List<String> = listOf(),
+    val wantedDids: List<String> = listOf(),
+    val maxMessageSizeBytes: Long? = null,
+)

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/JetStreamClient.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/JetStreamClient.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.launch
 import work.socialhub.kbsky.internal.share.InternalUtility
 import work.socialhub.kbsky.stream.entity.app.bsky.callback.JetStreamEventCallback
 import work.socialhub.kbsky.stream.entity.app.bsky.model.Event
+import work.socialhub.kbsky.stream.entity.app.bsky.model.SubscriberOptionsPayload
+import work.socialhub.kbsky.stream.entity.app.bsky.model.SubscriberOptionsUpdate
 import work.socialhub.kbsky.stream.entity.callback.ClosedCallback
 import work.socialhub.kbsky.stream.entity.callback.ErrorCallback
 import work.socialhub.kbsky.stream.entity.callback.OpenedCallback
@@ -16,6 +18,7 @@ class JetStreamClient(
 ) {
     var client = WebsocketRequest()
     var isOpen: Boolean = false
+    var deferredOptionsUpdate: DeferredOptionsUpdate? = null
 
     var eventCallback: JetStreamEventCallback? = null
     private var openedCallback: OpenedCallback? = null
@@ -37,6 +40,7 @@ class JetStreamClient(
         }
         this.client.onOpenListener = {
             this.isOpen = true
+            this.sendDeferredOptionsUpdate()
             this.openedCallback?.onOpened()
         }
         this.client.onCloseListener = {
@@ -53,6 +57,23 @@ class JetStreamClient(
     fun openAsync() {
         GlobalScope.launch {
             client.open()
+        }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun sendDeferredOptionsUpdate() {
+        deferredOptionsUpdate?.let { deferred ->
+            GlobalScope.launch {
+                try {
+                    updateOptions(
+                        wantedCollections = deferred.wantedCollections,
+                        wantedDids = deferred.wantedDids,
+                        maxMessageSizeBytes = deferred.maxMessageSizeBytes,
+                    )
+                } catch (e: Exception) {
+                    errorCallback?.onError(e)
+                }
+            }
         }
     }
 
@@ -73,5 +94,20 @@ class JetStreamClient(
 
     private fun onMessage(data: ByteArray) {
         // TODO: zstd の場合はこちらで処理することになる
+    }
+
+    suspend fun updateOptions(
+        wantedCollections: List<String> = listOf(),
+        wantedDids: List<String> = listOf(),
+        maxMessageSizeBytes: Long? = null,
+    ) {
+        val message = SubscriberOptionsUpdate(
+            payload = SubscriberOptionsPayload(
+                wantedCollections = wantedCollections,
+                wantedDids = wantedDids,
+                maxMessageSizeBytes = maxMessageSizeBytes,
+            )
+        )
+        client.sendText(InternalUtility.toJson(message))
     }
 }

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/model/SubscriberOptionsUpdate.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/entity/app/bsky/model/SubscriberOptionsUpdate.kt
@@ -1,0 +1,16 @@
+package work.socialhub.kbsky.stream.entity.app.bsky.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SubscriberOptionsUpdate(
+    val type: String = "options_update",
+    val payload: SubscriberOptionsPayload,
+)
+
+@Serializable
+data class SubscriberOptionsPayload(
+    val wantedCollections: List<String> = listOf(),
+    val wantedDids: List<String> = listOf(),
+    val maxMessageSizeBytes: Long? = null,
+)

--- a/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/internal/app/bsky/JetStreamResourceImpl.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kbsky/stream/internal/app/bsky/JetStreamResourceImpl.kt
@@ -7,6 +7,7 @@ import work.socialhub.kbsky.Bluesky
 import work.socialhub.kbsky.stream.BlueskyStreamConfig
 import work.socialhub.kbsky.stream.api.app.bsky.JetStreamResource
 import work.socialhub.kbsky.stream.api.entity.app.bsky.JetStreamSubscribeRequest
+import work.socialhub.kbsky.stream.entity.app.bsky.DeferredOptionsUpdate
 import work.socialhub.kbsky.stream.entity.app.bsky.JetStreamClient
 
 class JetStreamResourceImpl(
@@ -14,9 +15,15 @@ class JetStreamResourceImpl(
     private val config: BlueskyStreamConfig
 ) : JetStreamResource {
 
+    companion object {
+        const val MAX_URL_DIDS = 50
+    }
+
     override fun subscribe(
         request: JetStreamSubscribeRequest
     ): JetStreamClient {
+
+        val useOptionsUpdate = request.wantedDids.size > MAX_URL_DIDS
 
         val builder = URLBuilder().also { b ->
 
@@ -29,7 +36,7 @@ class JetStreamResourceImpl(
                     b.parameters.append("wantedCollections", wantedCollection)
                 }
             }
-            if (request.wantedDids.isNotEmpty()) {
+            if (!useOptionsUpdate && request.wantedDids.isNotEmpty()) {
                 for (wantedDid in request.wantedDids) {
                     b.parameters.append("wantedDids", wantedDid)
                 }
@@ -40,12 +47,26 @@ class JetStreamResourceImpl(
             request.maxMessageSizeBytes?.let {
                 b.parameters.append("maxMessageSizeBytes", it.toString())
             }
-            request.requireHello?.let {
-                b.parameters.append("requireHello", it.toString())
+            if (useOptionsUpdate) {
+                b.parameters.append("requireHello", "true")
+            } else {
+                request.requireHello?.let {
+                    b.parameters.append("requireHello", it.toString())
+                }
             }
             b.path("subscribe")
         }
 
-        return JetStreamClient(builder.buildString())
+        val client = JetStreamClient(builder.buildString())
+
+        if (useOptionsUpdate) {
+            client.deferredOptionsUpdate = DeferredOptionsUpdate(
+                wantedCollections = request.wantedCollections,
+                wantedDids = request.wantedDids,
+                maxMessageSizeBytes = request.maxMessageSizeBytes,
+            )
+        }
+
+        return client
     }
 }

--- a/stream/src/jvmTest/kotlin/work/socialhub/kbsky/stream/app/bsky/JetStreamOptionsUpdateTest.kt
+++ b/stream/src/jvmTest/kotlin/work/socialhub/kbsky/stream/app/bsky/JetStreamOptionsUpdateTest.kt
@@ -1,0 +1,178 @@
+package work.socialhub.kbsky.stream.app.bsky
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import work.socialhub.kbsky.stream.AbstractTest
+import work.socialhub.kbsky.stream.BlueskyStreamFactory
+import work.socialhub.kbsky.stream.api.entity.app.bsky.JetStreamSubscribeRequest
+import work.socialhub.kbsky.stream.entity.app.bsky.callback.JetStreamEventCallback
+import work.socialhub.kbsky.stream.entity.app.bsky.model.Event
+import work.socialhub.kbsky.stream.entity.callback.ErrorCallback
+import work.socialhub.kbsky.stream.entity.callback.OpenedCallback
+import kotlin.test.Test
+
+class JetStreamOptionsUpdateTest : AbstractTest() {
+
+    @Test
+    fun testSubscribeWithManyDids() {
+        runBlocking {
+            // 50 以上の DID を指定して requireHello + options_update が使われることを確認
+            val manyDids = (1..100).map { "did:plc:testdid${it.toString().padStart(4, '0')}" }
+
+            val stream = BlueskyStreamFactory
+                .instance()
+                .jetStream()
+                .subscribe(
+                    JetStreamSubscribeRequest().also {
+                        it.wantedCollections = listOf("app.bsky.feed.post")
+                        it.wantedDids = manyDids
+                    }
+                )
+
+            // URL に wantedDids が含まれていないことを確認
+            println("URI: ${stream.uri}")
+            assert(!stream.uri.contains("wantedDids")) {
+                "URL should not contain wantedDids when count > MAX_URL_DIDS"
+            }
+            assert(stream.uri.contains("requireHello=true")) {
+                "URL should contain requireHello=true"
+            }
+            assert(stream.deferredOptionsUpdate != null) {
+                "deferredOptionsUpdate should be set"
+            }
+            assert(stream.deferredOptionsUpdate!!.wantedDids.size == 100) {
+                "deferredOptionsUpdate should contain all DIDs"
+            }
+
+            println(">> URL construction test passed.")
+
+            stream.eventCallback(
+                object : JetStreamEventCallback {
+                    override fun onEvent(event: Event) {
+                        event.commit?.record?.asFeedPost?.let {
+                            println("Event: ${it.text}")
+                        }
+                    }
+                })
+
+            stream.openedCallback(
+                object : OpenedCallback {
+                    override fun onOpened() {
+                        println(">> opened (options_update sent)")
+                    }
+                })
+
+            stream.errorCallback(
+                object : ErrorCallback {
+                    override fun onError(e: Exception) {
+                        println(">> error: ${e.message}")
+                    }
+                })
+
+            launch { stream.open() }.let {
+                delay(5000)
+                it.cancel()
+                stream.close()
+            }
+        }
+    }
+
+    @Test
+    fun testSubscribeWithFewDids() {
+        runBlocking {
+            // 50 以下の DID では従来通り URL パラメータに含まれる
+            val fewDids = (1..10).map { "did:plc:testdid${it.toString().padStart(4, '0')}" }
+
+            val stream = BlueskyStreamFactory
+                .instance()
+                .jetStream()
+                .subscribe(
+                    JetStreamSubscribeRequest().also {
+                        it.wantedCollections = listOf("app.bsky.feed.post")
+                        it.wantedDids = fewDids
+                    }
+                )
+
+            // URL に wantedDids が含まれていることを確認
+            println("URI: ${stream.uri}")
+            assert(stream.uri.contains("wantedDids")) {
+                "URL should contain wantedDids when count <= MAX_URL_DIDS"
+            }
+            assert(!stream.uri.contains("requireHello")) {
+                "URL should not contain requireHello when not needed"
+            }
+            assert(stream.deferredOptionsUpdate == null) {
+                "deferredOptionsUpdate should not be set"
+            }
+
+            println(">> URL construction test for few DIDs passed.")
+
+            stream.eventCallback(
+                object : JetStreamEventCallback {
+                    override fun onEvent(event: Event) {
+                        event.commit?.record?.asFeedPost?.let {
+                            println("Event: ${it.text}")
+                        }
+                    }
+                })
+
+            stream.openedCallback(
+                object : OpenedCallback {
+                    override fun onOpened() {
+                        println(">> opened (traditional URL params)")
+                    }
+                })
+
+            launch { stream.open() }.let {
+                delay(5000)
+                it.cancel()
+                stream.close()
+            }
+        }
+    }
+
+    @Test
+    fun testManualUpdateOptions() {
+        runBlocking {
+            val stream = BlueskyStreamFactory
+                .instance()
+                .jetStream()
+                .subscribe(
+                    JetStreamSubscribeRequest().also {
+                        it.wantedCollections = listOf("app.bsky.feed.post")
+                        it.requireHello = true
+                    }
+                )
+
+            stream.eventCallback(
+                object : JetStreamEventCallback {
+                    override fun onEvent(event: Event) {
+                        event.commit?.record?.asFeedPost?.let {
+                            println("Event: ${it.text}")
+                        }
+                    }
+                })
+
+            stream.openedCallback(
+                object : OpenedCallback {
+                    override fun onOpened() {
+                        println(">> opened, manually sending options update")
+                    }
+                })
+
+            launch { stream.open() }.let {
+                delay(2000)
+                // 手動で updateOptions を呼ぶ
+                stream.updateOptions(
+                    wantedCollections = listOf("app.bsky.feed.post"),
+                    wantedDids = listOf("did:plc:z72i7hdynmk6r22z27h6tvur"),
+                )
+                println(">> manual updateOptions sent")
+                delay(5000)
+                it.cancel()
+                stream.close()
+            }
+        }
+    }
+}


### PR DESCRIPTION
…oo long

When wantedDids exceeds 50 entries, the WebSocket URL becomes too long and causes connection failures. This change uses Jetstream's requireHello + options_update mechanism to send wantedDids after connection is established instead of encoding them in the URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deferred subscriber options updates for JetStream streams, allowing subscription parameters to be modified after the WebSocket connection is established.
  * Improved handling of large subscriber requests by automatically switching to deferred option updates when necessary.

* **Tests**
  * Added comprehensive test suite for options update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->