### PR TITLE
Remove deprecated macosX64 target

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
         }
     }
 
-    js(IR) {
+    js {
         nodejs()
         browser()
 

--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -35,7 +35,6 @@ kotlin {
         iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
-        macosX64(),
         macosArm64(),
     ).forEach {
         it.binaries.framework {

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
         iosX64()
         iosArm64()
         iosSimulatorArm64()
-        macosX64()
         macosArm64()
     }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
         }
     }
 
-    js(IR) {
+    js {
         nodejs()
         browser()
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,7 +34,6 @@ kotlin {
         iosX64()
         iosArm64()
         iosSimulatorArm64()
-        macosX64()
         macosArm64()
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ mavenCentralAutomaticPublishing=true
 
 # Java Toolchain Auto-Provisioning
 org.gradle.java.installations.auto-detect=true
-org.gradle.java.installations.auto-download=truekotlin.native.ignoreDisabledTargets=true
+org.gradle.java.installations.auto-download=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ mavenCentralAutomaticPublishing=true
 
 # Java Toolchain Auto-Provisioning
 org.gradle.java.installations.auto-detect=true
-org.gradle.java.installations.auto-download=true
+org.gradle.java.installations.auto-download=truekotlin.native.ignoreDisabledTargets=true

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
         }
     }
 
-    js(IR) {
+    js {
         nodejs()
         browser()
 

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -34,7 +34,6 @@ kotlin {
         iosX64()
         iosArm64()
         iosSimulatorArm64()
-        macosX64()
         macosArm64()
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined JavaScript compilation configuration across modules.
  * Intel-based macOS (x64) architecture support removed; ARM64 macOS remains fully supported.
  * Enhanced build infrastructure with automatic Java toolchain provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->