### PR TITLE
Add chat.bsky.group (group chat) support

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/Bluesky.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/Bluesky.kt
@@ -9,6 +9,7 @@ import work.socialhub.kbsky.api.app.bsky.NotificationResource
 import work.socialhub.kbsky.api.app.bsky.UnspeccedResource
 import work.socialhub.kbsky.api.app.bsky.VideoResource
 import work.socialhub.kbsky.api.chat.bsky.ConvoResource
+import work.socialhub.kbsky.api.chat.bsky.GroupResource
 import kotlin.js.JsExport
 
 @JsExport
@@ -21,4 +22,5 @@ interface Bluesky : ATProtocol {
     fun unspecced(): UnspeccedResource
     fun video(): VideoResource
     fun convo(): ConvoResource
+    fun group(): GroupResource
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -99,20 +99,48 @@ object BlueskyTypes {
     /// CHAT.BSKY
     /// ----------------------------------------------------------------------- ///
 
+    // Actor
+    const val ChatActorDefs = "chat.bsky.actor.defs"
+
     // Convo
+    const val ConvoAcceptConvo = "chat.bsky.convo.acceptConvo"
     const val ConvoAddReaction = "chat.bsky.convo.addReaction"
     const val ConvoDefs = "chat.bsky.convo.defs"
     const val ConvoDeleteMessageForSelf = "chat.bsky.convo.deleteMessageForSelf"
     const val ConvoGetConvo = "chat.bsky.convo.getConvo"
+    const val ConvoGetConvoAvailability = "chat.bsky.convo.getConvoAvailability"
     const val ConvoGetConvoForMembers = "chat.bsky.convo.getConvoForMembers"
+    const val ConvoGetConvoMembers = "chat.bsky.convo.getConvoMembers"
     const val ConvoGetLog = "chat.bsky.convo.getLog"
     const val ConvoGetMessages = "chat.bsky.convo.getMessages"
     const val ConvoLeaveConvo = "chat.bsky.convo.leaveConvo"
+    const val ConvoListConvoRequests = "chat.bsky.convo.listConvoRequests"
     const val ConvoListConvos = "chat.bsky.convo.listConvos"
+    const val ConvoLockConvo = "chat.bsky.convo.lockConvo"
     const val ConvoMuteConvo = "chat.bsky.convo.muteConvo"
     const val ConvoRemoveReaction = "chat.bsky.convo.removeReaction"
     const val ConvoSendMessage = "chat.bsky.convo.sendMessage"
     const val ConvoSendMessageBatch = "chat.bsky.convo.sendMessageBatch"
+    const val ConvoUnlockConvo = "chat.bsky.convo.unlockConvo"
     const val ConvoUnmuteConvo = "chat.bsky.convo.unmuteConvo"
     const val ConvoUpdateRead = "chat.bsky.convo.updateRead"
+
+    // Group
+    const val GroupDefs = "chat.bsky.group.defs"
+    const val GroupAddMembers = "chat.bsky.group.addMembers"
+    const val GroupApproveJoinRequest = "chat.bsky.group.approveJoinRequest"
+    const val GroupCreateGroup = "chat.bsky.group.createGroup"
+    const val GroupCreateJoinLink = "chat.bsky.group.createJoinLink"
+    const val GroupDisableJoinLink = "chat.bsky.group.disableJoinLink"
+    const val GroupEditGroup = "chat.bsky.group.editGroup"
+    const val GroupEditJoinLink = "chat.bsky.group.editJoinLink"
+    const val GroupEnableJoinLink = "chat.bsky.group.enableJoinLink"
+    const val GroupGetJoinLinkPreviews = "chat.bsky.group.getJoinLinkPreviews"
+    const val GroupListJoinRequests = "chat.bsky.group.listJoinRequests"
+    const val GroupListMutualGroups = "chat.bsky.group.listMutualGroups"
+    const val GroupRejectJoinRequest = "chat.bsky.group.rejectJoinRequest"
+    const val GroupRemoveMembers = "chat.bsky.group.removeMembers"
+    const val GroupRequestJoin = "chat.bsky.group.requestJoin"
+    const val GroupUpdateJoinRequestsRead = "chat.bsky.group.updateJoinRequestsRead"
+    const val GroupWithdrawJoinRequest = "chat.bsky.group.withdrawJoinRequest"
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/ConvoResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/ConvoResource.kt
@@ -1,14 +1,24 @@
 package work.socialhub.kbsky.api.chat.bsky
 
 
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAcceptConvoRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAcceptConvoResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoAvailabilityRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoAvailabilityResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoForMembersRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoForMembersResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoMembersRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoMembersResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLockConvoRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLockConvoResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoUnlockConvoRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoUnlockConvoResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetListConvosRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetListConvosResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetLogRequest
@@ -193,4 +203,64 @@ interface ConvoResource {
     fun removeReactionBlocking(
         request: ConvoRemoveReactionRequest
     ): Response<ConvoRemoveReactionResponse>
+
+    /**
+     * chat.bsky.convo.acceptConvo
+     */
+    suspend fun acceptConvo(
+        request: ConvoAcceptConvoRequest
+    ): Response<ConvoAcceptConvoResponse>
+
+    @JsExport.Ignore
+    fun acceptConvoBlocking(
+        request: ConvoAcceptConvoRequest
+    ): Response<ConvoAcceptConvoResponse>
+
+    /**
+     * chat.bsky.convo.lockConvo
+     */
+    suspend fun lockConvo(
+        request: ConvoLockConvoRequest
+    ): Response<ConvoLockConvoResponse>
+
+    @JsExport.Ignore
+    fun lockConvoBlocking(
+        request: ConvoLockConvoRequest
+    ): Response<ConvoLockConvoResponse>
+
+    /**
+     * chat.bsky.convo.unlockConvo
+     */
+    suspend fun unlockConvo(
+        request: ConvoUnlockConvoRequest
+    ): Response<ConvoUnlockConvoResponse>
+
+    @JsExport.Ignore
+    fun unlockConvoBlocking(
+        request: ConvoUnlockConvoRequest
+    ): Response<ConvoUnlockConvoResponse>
+
+    /**
+     * chat.bsky.convo.getConvoMembers
+     */
+    suspend fun getConvoMembers(
+        request: ConvoGetConvoMembersRequest
+    ): Response<ConvoGetConvoMembersResponse>
+
+    @JsExport.Ignore
+    fun getConvoMembersBlocking(
+        request: ConvoGetConvoMembersRequest
+    ): Response<ConvoGetConvoMembersResponse>
+
+    /**
+     * chat.bsky.convo.getConvoAvailability
+     */
+    suspend fun getConvoAvailability(
+        request: ConvoGetConvoAvailabilityRequest
+    ): Response<ConvoGetConvoAvailabilityResponse>
+
+    @JsExport.Ignore
+    fun getConvoAvailabilityBlocking(
+        request: ConvoGetConvoAvailabilityRequest
+    ): Response<ConvoGetConvoAvailabilityResponse>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/GroupResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/chat/bsky/GroupResource.kt
@@ -1,0 +1,236 @@
+package work.socialhub.kbsky.api.chat.bsky
+
+
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupAddMembersRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupAddMembersResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupApproveJoinRequestRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupApproveJoinRequestResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateGroupRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateGroupResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupDisableJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupDisableJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditGroupRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditGroupResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEnableJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEnableJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupGetJoinLinkPreviewsRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupGetJoinLinkPreviewsResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListJoinRequestsRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListJoinRequestsResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListMutualGroupsRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListMutualGroupsResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRejectJoinRequestRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRemoveMembersRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRemoveMembersResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRequestJoinRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRequestJoinResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupUpdateJoinRequestsReadRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupWithdrawJoinRequestRequest
+import work.socialhub.kbsky.api.entity.share.Response
+import work.socialhub.kbsky.api.entity.share.ResponseUnit
+import kotlin.js.JsExport
+
+/**
+ * Chat/Bluesky/Group
+ *
+ * [Reference](https://github.com/bluesky-social/atproto/tree/main/lexicons/chat/bsky/group)
+ */
+@JsExport
+interface GroupResource {
+
+    /**
+     * chat.bsky.group.createGroup
+     */
+    suspend fun createGroup(
+        request: GroupCreateGroupRequest
+    ): Response<GroupCreateGroupResponse>
+
+    @JsExport.Ignore
+    fun createGroupBlocking(
+        request: GroupCreateGroupRequest
+    ): Response<GroupCreateGroupResponse>
+
+    /**
+     * chat.bsky.group.addMembers
+     */
+    suspend fun addMembers(
+        request: GroupAddMembersRequest
+    ): Response<GroupAddMembersResponse>
+
+    @JsExport.Ignore
+    fun addMembersBlocking(
+        request: GroupAddMembersRequest
+    ): Response<GroupAddMembersResponse>
+
+    /**
+     * chat.bsky.group.removeMembers
+     */
+    suspend fun removeMembers(
+        request: GroupRemoveMembersRequest
+    ): Response<GroupRemoveMembersResponse>
+
+    @JsExport.Ignore
+    fun removeMembersBlocking(
+        request: GroupRemoveMembersRequest
+    ): Response<GroupRemoveMembersResponse>
+
+    /**
+     * chat.bsky.group.editGroup
+     */
+    suspend fun editGroup(
+        request: GroupEditGroupRequest
+    ): Response<GroupEditGroupResponse>
+
+    @JsExport.Ignore
+    fun editGroupBlocking(
+        request: GroupEditGroupRequest
+    ): Response<GroupEditGroupResponse>
+
+    /**
+     * chat.bsky.group.requestJoin
+     */
+    suspend fun requestJoin(
+        request: GroupRequestJoinRequest
+    ): Response<GroupRequestJoinResponse>
+
+    @JsExport.Ignore
+    fun requestJoinBlocking(
+        request: GroupRequestJoinRequest
+    ): Response<GroupRequestJoinResponse>
+
+    /**
+     * chat.bsky.group.withdrawJoinRequest
+     */
+    suspend fun withdrawJoinRequest(
+        request: GroupWithdrawJoinRequestRequest
+    ): ResponseUnit
+
+    @JsExport.Ignore
+    fun withdrawJoinRequestBlocking(
+        request: GroupWithdrawJoinRequestRequest
+    ): ResponseUnit
+
+    /**
+     * chat.bsky.group.listJoinRequests
+     */
+    suspend fun listJoinRequests(
+        request: GroupListJoinRequestsRequest
+    ): Response<GroupListJoinRequestsResponse>
+
+    @JsExport.Ignore
+    fun listJoinRequestsBlocking(
+        request: GroupListJoinRequestsRequest
+    ): Response<GroupListJoinRequestsResponse>
+
+    /**
+     * chat.bsky.group.approveJoinRequest
+     */
+    suspend fun approveJoinRequest(
+        request: GroupApproveJoinRequestRequest
+    ): Response<GroupApproveJoinRequestResponse>
+
+    @JsExport.Ignore
+    fun approveJoinRequestBlocking(
+        request: GroupApproveJoinRequestRequest
+    ): Response<GroupApproveJoinRequestResponse>
+
+    /**
+     * chat.bsky.group.rejectJoinRequest
+     */
+    suspend fun rejectJoinRequest(
+        request: GroupRejectJoinRequestRequest
+    ): ResponseUnit
+
+    @JsExport.Ignore
+    fun rejectJoinRequestBlocking(
+        request: GroupRejectJoinRequestRequest
+    ): ResponseUnit
+
+    /**
+     * chat.bsky.group.updateJoinRequestsRead
+     */
+    suspend fun updateJoinRequestsRead(
+        request: GroupUpdateJoinRequestsReadRequest
+    ): ResponseUnit
+
+    @JsExport.Ignore
+    fun updateJoinRequestsReadBlocking(
+        request: GroupUpdateJoinRequestsReadRequest
+    ): ResponseUnit
+
+    /**
+     * chat.bsky.group.createJoinLink
+     */
+    suspend fun createJoinLink(
+        request: GroupCreateJoinLinkRequest
+    ): Response<GroupCreateJoinLinkResponse>
+
+    @JsExport.Ignore
+    fun createJoinLinkBlocking(
+        request: GroupCreateJoinLinkRequest
+    ): Response<GroupCreateJoinLinkResponse>
+
+    /**
+     * chat.bsky.group.editJoinLink
+     */
+    suspend fun editJoinLink(
+        request: GroupEditJoinLinkRequest
+    ): Response<GroupEditJoinLinkResponse>
+
+    @JsExport.Ignore
+    fun editJoinLinkBlocking(
+        request: GroupEditJoinLinkRequest
+    ): Response<GroupEditJoinLinkResponse>
+
+    /**
+     * chat.bsky.group.enableJoinLink
+     */
+    suspend fun enableJoinLink(
+        request: GroupEnableJoinLinkRequest
+    ): Response<GroupEnableJoinLinkResponse>
+
+    @JsExport.Ignore
+    fun enableJoinLinkBlocking(
+        request: GroupEnableJoinLinkRequest
+    ): Response<GroupEnableJoinLinkResponse>
+
+    /**
+     * chat.bsky.group.disableJoinLink
+     */
+    suspend fun disableJoinLink(
+        request: GroupDisableJoinLinkRequest
+    ): Response<GroupDisableJoinLinkResponse>
+
+    @JsExport.Ignore
+    fun disableJoinLinkBlocking(
+        request: GroupDisableJoinLinkRequest
+    ): Response<GroupDisableJoinLinkResponse>
+
+    /**
+     * chat.bsky.group.getJoinLinkPreviews
+     */
+    suspend fun getJoinLinkPreviews(
+        request: GroupGetJoinLinkPreviewsRequest
+    ): Response<GroupGetJoinLinkPreviewsResponse>
+
+    @JsExport.Ignore
+    fun getJoinLinkPreviewsBlocking(
+        request: GroupGetJoinLinkPreviewsRequest
+    ): Response<GroupGetJoinLinkPreviewsResponse>
+
+    /**
+     * chat.bsky.group.listMutualGroups
+     */
+    suspend fun listMutualGroups(
+        request: GroupListMutualGroupsRequest
+    ): Response<GroupListMutualGroupsResponse>
+
+    @JsExport.Ignore
+    fun listMutualGroupsBlocking(
+        request: GroupListMutualGroupsRequest
+    ): Response<GroupListMutualGroupsResponse>
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAcceptConvoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAcceptConvoRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class ConvoAcceptConvoRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAcceptConvoResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoAcceptConvoResponse.kt
@@ -1,0 +1,11 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class ConvoAcceptConvoResponse(
+    var rev: String? = null
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoAvailabilityRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoAvailabilityRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class ConvoGetConvoAvailabilityRequest(
+    override val auth: AuthProvider,
+    var members: List<String> = emptyList(),
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("members", members)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoAvailabilityResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoAvailabilityResponse.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class ConvoGetConvoAvailabilityResponse(
+    var canChat: Boolean,
+    var convo: ConvoDefsConvoView? = null
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoMembersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoMembersRequest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class ConvoGetConvoMembersRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var limit: Int? = null,
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoMembersResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetConvoMembersResponse.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class ConvoGetConvoMembersResponse(
+    var cursor: String? = null,
+    var members: List<ActorDefsProfileViewBasic>
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetLogResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoGetLogResponse.kt
@@ -8,5 +8,6 @@ import kotlin.js.JsExport
 @Serializable
 @JsExport
 data class ConvoGetLogResponse(
-    var logs: List<ConvoDefsLogUnion>
+    var cursor: String? = null,
+    var logs: List<ConvoDefsLogUnion>,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoLockConvoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoLockConvoRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class ConvoLockConvoRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoLockConvoResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoLockConvoResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class ConvoLockConvoResponse(
+    var convo: ConvoDefsConvoView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUnlockConvoRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUnlockConvoRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class ConvoUnlockConvoRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUnlockConvoResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/convo/ConvoUnlockConvoResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.convo
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class ConvoUnlockConvoResponse(
+    var convo: ConvoDefsConvoView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupAddMembersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupAddMembersRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupAddMembersRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var members: List<String> = emptyList(),
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("members", members)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupAddMembersResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupAddMembersResponse.kt
@@ -1,0 +1,14 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupAddMembersResponse(
+    var convo: ConvoDefsConvoView,
+    var addedMembers: List<ActorDefsProfileViewBasic>
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupAddMembersResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupAddMembersResponse.kt
@@ -10,5 +10,5 @@ import kotlin.js.JsExport
 @JsExport
 data class GroupAddMembersResponse(
     var convo: ConvoDefsConvoView,
-    var addedMembers: List<ActorDefsProfileViewBasic>
+    var addedMembers: List<ActorDefsProfileViewBasic>? = null,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupApproveJoinRequestRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupApproveJoinRequestRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupApproveJoinRequestRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var member: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("member", member)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupApproveJoinRequestResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupApproveJoinRequestResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupApproveJoinRequestResponse(
+    var convo: ConvoDefsConvoView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateGroupRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateGroupRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupCreateGroupRequest(
+    override val auth: AuthProvider,
+    var members: List<String> = emptyList(),
+    var name: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("members", members)
+            it.addParam("name", name)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateGroupResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateGroupResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupCreateGroupResponse(
+    var convo: ConvoDefsConvoView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateJoinLinkRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateJoinLinkRequest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupCreateJoinLinkRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var joinRule: String = "",
+    var requireApproval: Boolean? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("joinRule", joinRule)
+            it.addParam("requireApproval", requireApproval)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateJoinLinkResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupCreateJoinLinkResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupCreateJoinLinkResponse(
+    var joinLink: GroupDefsJoinLinkView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupDisableJoinLinkRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupDisableJoinLinkRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupDisableJoinLinkRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupDisableJoinLinkResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupDisableJoinLinkResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupDisableJoinLinkResponse(
+    var joinLink: GroupDefsJoinLinkView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditGroupRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditGroupRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupEditGroupRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var name: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("name", name)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditGroupResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditGroupResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupEditGroupResponse(
+    var convo: ConvoDefsConvoView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditJoinLinkRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditJoinLinkRequest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupEditJoinLinkRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var requireApproval: Boolean? = null,
+    var joinRule: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("requireApproval", requireApproval)
+            it.addParam("joinRule", joinRule)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditJoinLinkResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEditJoinLinkResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupEditJoinLinkResponse(
+    var joinLink: GroupDefsJoinLinkView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEnableJoinLinkRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEnableJoinLinkRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupEnableJoinLinkRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEnableJoinLinkResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupEnableJoinLinkResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupEnableJoinLinkResponse(
+    var joinLink: GroupDefsJoinLinkView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupGetJoinLinkPreviewsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupGetJoinLinkPreviewsRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupGetJoinLinkPreviewsRequest(
+    override val auth: AuthProvider,
+    var codes: List<String> = emptyList(),
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("codes", codes)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupGetJoinLinkPreviewsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupGetJoinLinkPreviewsResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkPreviewUnion
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupGetJoinLinkPreviewsResponse(
+    var joinLinkPreviews: List<GroupDefsJoinLinkPreviewUnion>
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListJoinRequestsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListJoinRequestsRequest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupListJoinRequestsRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var limit: Int? = null,
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListJoinRequestsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListJoinRequestsResponse.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinRequestView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupListJoinRequestsResponse(
+    var cursor: String? = null,
+    var requests: List<GroupDefsJoinRequestView>
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListMutualGroupsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListMutualGroupsRequest.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupListMutualGroupsRequest(
+    override val auth: AuthProvider,
+    var subject: String = "",
+    var limit: Int? = null,
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("subject", subject)
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListMutualGroupsResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupListMutualGroupsResponse.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupListMutualGroupsResponse(
+    var cursor: String? = null,
+    var convos: List<ConvoDefsConvoView>
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRejectJoinRequestRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRejectJoinRequestRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupRejectJoinRequestRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var member: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("member", member)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRemoveMembersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRemoveMembersRequest.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupRemoveMembersRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+    var members: List<String> = emptyList(),
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+            it.addParam("members", members)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRemoveMembersResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRemoveMembersResponse.kt
@@ -1,0 +1,12 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupRemoveMembersResponse(
+    var convo: ConvoDefsConvoView
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRequestJoinRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRequestJoinRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupRequestJoinRequest(
+    override val auth: AuthProvider,
+    var code: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("code", code)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRequestJoinResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupRequestJoinResponse.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class GroupRequestJoinResponse(
+    var status: String,
+    var convo: ConvoDefsConvoView? = null
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupUpdateJoinRequestsReadRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupUpdateJoinRequestsReadRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupUpdateJoinRequestsReadRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupWithdrawJoinRequestRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/chat/bsky/group/GroupWithdrawJoinRequestRequest.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.api.entity.chat.bsky.group
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class GroupWithdrawJoinRequestRequest(
+    override val auth: AuthProvider,
+    var convoId: String = "",
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("convoId", convoId)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/BlueskyImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/BlueskyImpl.kt
@@ -10,6 +10,7 @@ import work.socialhub.kbsky.api.app.bsky.NotificationResource
 import work.socialhub.kbsky.api.app.bsky.UnspeccedResource
 import work.socialhub.kbsky.api.app.bsky.VideoResource
 import work.socialhub.kbsky.api.chat.bsky.ConvoResource
+import work.socialhub.kbsky.api.chat.bsky.GroupResource
 import work.socialhub.kbsky.internal.app.bsky.ActorResourceImpl
 import work.socialhub.kbsky.internal.app.bsky.FeedResourceImpl
 import work.socialhub.kbsky.internal.app.bsky.GraphResourceImpl
@@ -18,6 +19,7 @@ import work.socialhub.kbsky.internal.app.bsky.NotificationResourceImpl
 import work.socialhub.kbsky.internal.app.bsky.UnspeccedResourceImpl
 import work.socialhub.kbsky.internal.app.bsky.VideoResourceImpl
 import work.socialhub.kbsky.internal.chat.bsky.ConvoResourceImpl
+import work.socialhub.kbsky.internal.chat.bsky.GroupResourceImpl
 
 class BlueskyImpl(
     config: BlueskyConfig
@@ -31,6 +33,7 @@ class BlueskyImpl(
     protected val undoc: UnspeccedResource = UnspeccedResourceImpl(config)
     protected val video: VideoResource = VideoResourceImpl(config)
     protected val convo: ConvoResource = ConvoResourceImpl(config)
+    protected val group: GroupResource = GroupResourceImpl(config)
 
     /**
      * {@inheritDoc}
@@ -71,4 +74,9 @@ class BlueskyImpl(
      * {@inheritDoc}
      */
     override fun convo() = convo
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun group() = group
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/ConvoResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/ConvoResourceImpl.kt
@@ -3,14 +3,24 @@ package work.socialhub.kbsky.internal.chat.bsky
 import work.socialhub.kbsky.ATProtocolConfig
 import work.socialhub.kbsky.BlueskyTypes
 import work.socialhub.kbsky.api.chat.bsky.ConvoResource
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAcceptConvoRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAcceptConvoResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoAddReactionResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoDeleteMessageForSelfResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoAvailabilityRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoAvailabilityResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoForMembersRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoForMembersResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoMembersRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoMembersResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetConvoResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLockConvoRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoLockConvoResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoUnlockConvoRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoUnlockConvoResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetListConvosRequest
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetListConvosResponse
 import work.socialhub.kbsky.api.entity.chat.bsky.convo.ConvoGetLogRequest
@@ -224,6 +234,76 @@ class ConvoResourceImpl(
 
     override fun removeReactionBlocking(request: ConvoRemoveReactionRequest): Response<ConvoRemoveReactionResponse> =
         toBlocking { removeReaction(request) }
+
+    override suspend fun acceptConvo(
+        request: ConvoAcceptConvoRequest
+    ): Response<ConvoAcceptConvoResponse> {
+
+        return proceedPost(
+            BlueskyTypes.ConvoAcceptConvo,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun acceptConvoBlocking(request: ConvoAcceptConvoRequest): Response<ConvoAcceptConvoResponse> =
+        toBlocking { acceptConvo(request) }
+
+    override suspend fun lockConvo(
+        request: ConvoLockConvoRequest
+    ): Response<ConvoLockConvoResponse> {
+
+        return proceedPost(
+            BlueskyTypes.ConvoLockConvo,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun lockConvoBlocking(request: ConvoLockConvoRequest): Response<ConvoLockConvoResponse> =
+        toBlocking { lockConvo(request) }
+
+    override suspend fun unlockConvo(
+        request: ConvoUnlockConvoRequest
+    ): Response<ConvoUnlockConvoResponse> {
+
+        return proceedPost(
+            BlueskyTypes.ConvoUnlockConvo,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun unlockConvoBlocking(request: ConvoUnlockConvoRequest): Response<ConvoUnlockConvoResponse> =
+        toBlocking { unlockConvo(request) }
+
+    override suspend fun getConvoMembers(
+        request: ConvoGetConvoMembersRequest
+    ): Response<ConvoGetConvoMembersResponse> {
+
+        return proceedGet(
+            BlueskyTypes.ConvoGetConvoMembers,
+            request.toMap(),
+            request.auth,
+        )
+    }
+
+    override fun getConvoMembersBlocking(request: ConvoGetConvoMembersRequest): Response<ConvoGetConvoMembersResponse> =
+        toBlocking { getConvoMembers(request) }
+
+    override suspend fun getConvoAvailability(
+        request: ConvoGetConvoAvailabilityRequest
+    ): Response<ConvoGetConvoAvailabilityResponse> {
+
+        return proceedGet(
+            BlueskyTypes.ConvoGetConvoAvailability,
+            request.toMap(),
+            request.auth,
+        )
+    }
+
+    override fun getConvoAvailabilityBlocking(request: ConvoGetConvoAvailabilityRequest): Response<ConvoGetConvoAvailabilityResponse> =
+        toBlocking { getConvoAvailability(request) }
 
     private suspend inline fun <reified T> proceedGet(
         id: String,

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/GroupResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/GroupResourceImpl.kt
@@ -248,11 +248,17 @@ class GroupResourceImpl(
         request: GroupGetJoinLinkPreviewsRequest
     ): Response<GroupGetJoinLinkPreviewsResponse> {
 
-        return proceedGet(
-            BlueskyTypes.GroupGetJoinLinkPreviews,
-            request.toMap(),
-            request.auth,
-        )
+        // `codes` is an array parameter and must be expanded as codes=v1&codes=v2.
+        // khttpclient's queries(Map) calls toString() on List values, producing "[v1,v2]",
+        // so we take a dedicated path that calls query() for each element.
+        return proceed {
+            val req = httpRequest(config)
+                .url(xrpc(config, BlueskyTypes.GroupGetJoinLinkPreviews))
+                .header("Atproto-Proxy", "did:web:api.bsky.chat#bsky_chat")
+                .accept(MediaType.JSON)
+            request.codes.forEach { req.query("codes", it) }
+            req.getWithAuth(request.auth)
+        }
     }
 
     override fun getJoinLinkPreviewsBlocking(request: GroupGetJoinLinkPreviewsRequest): Response<GroupGetJoinLinkPreviewsResponse> =

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/GroupResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/chat/bsky/GroupResourceImpl.kt
@@ -1,0 +1,319 @@
+package work.socialhub.kbsky.internal.chat.bsky
+
+import work.socialhub.kbsky.ATProtocolConfig
+import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.api.chat.bsky.GroupResource
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupAddMembersRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupAddMembersResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupApproveJoinRequestRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupApproveJoinRequestResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateGroupRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateGroupResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupDisableJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupDisableJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditGroupRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditGroupResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEditJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEnableJoinLinkRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupEnableJoinLinkResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupGetJoinLinkPreviewsRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupGetJoinLinkPreviewsResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListJoinRequestsRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListJoinRequestsResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListMutualGroupsRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupListMutualGroupsResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRejectJoinRequestRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRemoveMembersRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRemoveMembersResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRequestJoinRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRequestJoinResponse
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupUpdateJoinRequestsReadRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupWithdrawJoinRequestRequest
+import work.socialhub.kbsky.api.entity.share.Response
+import work.socialhub.kbsky.api.entity.share.ResponseUnit
+import work.socialhub.kbsky.auth.AuthProvider
+import work.socialhub.kbsky.internal.share.InternalUtility.getWithAuth
+import work.socialhub.kbsky.internal.share.InternalUtility.httpRequest
+import work.socialhub.kbsky.internal.share.InternalUtility.postWithAuth
+import work.socialhub.kbsky.internal.share.InternalUtility.proceed
+import work.socialhub.kbsky.internal.share.InternalUtility.proceedUnit
+import work.socialhub.kbsky.internal.share.InternalUtility.xrpc
+import work.socialhub.kbsky.util.MediaType
+import work.socialhub.kbsky.util.toBlocking
+
+class GroupResourceImpl(
+    private val config: ATProtocolConfig
+) : GroupResource {
+
+    override suspend fun createGroup(
+        request: GroupCreateGroupRequest
+    ): Response<GroupCreateGroupResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupCreateGroup,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun createGroupBlocking(request: GroupCreateGroupRequest): Response<GroupCreateGroupResponse> =
+        toBlocking { createGroup(request) }
+
+    override suspend fun addMembers(
+        request: GroupAddMembersRequest
+    ): Response<GroupAddMembersResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupAddMembers,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun addMembersBlocking(request: GroupAddMembersRequest): Response<GroupAddMembersResponse> =
+        toBlocking { addMembers(request) }
+
+    override suspend fun removeMembers(
+        request: GroupRemoveMembersRequest
+    ): Response<GroupRemoveMembersResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupRemoveMembers,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun removeMembersBlocking(request: GroupRemoveMembersRequest): Response<GroupRemoveMembersResponse> =
+        toBlocking { removeMembers(request) }
+
+    override suspend fun editGroup(
+        request: GroupEditGroupRequest
+    ): Response<GroupEditGroupResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupEditGroup,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun editGroupBlocking(request: GroupEditGroupRequest): Response<GroupEditGroupResponse> =
+        toBlocking { editGroup(request) }
+
+    override suspend fun requestJoin(
+        request: GroupRequestJoinRequest
+    ): Response<GroupRequestJoinResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupRequestJoin,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun requestJoinBlocking(request: GroupRequestJoinRequest): Response<GroupRequestJoinResponse> =
+        toBlocking { requestJoin(request) }
+
+    override suspend fun withdrawJoinRequest(
+        request: GroupWithdrawJoinRequestRequest
+    ): ResponseUnit {
+
+        return proceedPostUnit(
+            BlueskyTypes.GroupWithdrawJoinRequest,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun withdrawJoinRequestBlocking(request: GroupWithdrawJoinRequestRequest): ResponseUnit =
+        toBlocking { withdrawJoinRequest(request) }
+
+    override suspend fun listJoinRequests(
+        request: GroupListJoinRequestsRequest
+    ): Response<GroupListJoinRequestsResponse> {
+
+        return proceedGet(
+            BlueskyTypes.GroupListJoinRequests,
+            request.toMap(),
+            request.auth,
+        )
+    }
+
+    override fun listJoinRequestsBlocking(request: GroupListJoinRequestsRequest): Response<GroupListJoinRequestsResponse> =
+        toBlocking { listJoinRequests(request) }
+
+    override suspend fun approveJoinRequest(
+        request: GroupApproveJoinRequestRequest
+    ): Response<GroupApproveJoinRequestResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupApproveJoinRequest,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun approveJoinRequestBlocking(request: GroupApproveJoinRequestRequest): Response<GroupApproveJoinRequestResponse> =
+        toBlocking { approveJoinRequest(request) }
+
+    override suspend fun rejectJoinRequest(
+        request: GroupRejectJoinRequestRequest
+    ): ResponseUnit {
+
+        return proceedPostUnit(
+            BlueskyTypes.GroupRejectJoinRequest,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun rejectJoinRequestBlocking(request: GroupRejectJoinRequestRequest): ResponseUnit =
+        toBlocking { rejectJoinRequest(request) }
+
+    override suspend fun updateJoinRequestsRead(
+        request: GroupUpdateJoinRequestsReadRequest
+    ): ResponseUnit {
+
+        return proceedPostUnit(
+            BlueskyTypes.GroupUpdateJoinRequestsRead,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun updateJoinRequestsReadBlocking(request: GroupUpdateJoinRequestsReadRequest): ResponseUnit =
+        toBlocking { updateJoinRequestsRead(request) }
+
+    override suspend fun createJoinLink(
+        request: GroupCreateJoinLinkRequest
+    ): Response<GroupCreateJoinLinkResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupCreateJoinLink,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun createJoinLinkBlocking(request: GroupCreateJoinLinkRequest): Response<GroupCreateJoinLinkResponse> =
+        toBlocking { createJoinLink(request) }
+
+    override suspend fun editJoinLink(
+        request: GroupEditJoinLinkRequest
+    ): Response<GroupEditJoinLinkResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupEditJoinLink,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun editJoinLinkBlocking(request: GroupEditJoinLinkRequest): Response<GroupEditJoinLinkResponse> =
+        toBlocking { editJoinLink(request) }
+
+    override suspend fun enableJoinLink(
+        request: GroupEnableJoinLinkRequest
+    ): Response<GroupEnableJoinLinkResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupEnableJoinLink,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun enableJoinLinkBlocking(request: GroupEnableJoinLinkRequest): Response<GroupEnableJoinLinkResponse> =
+        toBlocking { enableJoinLink(request) }
+
+    override suspend fun disableJoinLink(
+        request: GroupDisableJoinLinkRequest
+    ): Response<GroupDisableJoinLinkResponse> {
+
+        return proceedPost(
+            BlueskyTypes.GroupDisableJoinLink,
+            request.toMappedJson(),
+            request.auth,
+        )
+    }
+
+    override fun disableJoinLinkBlocking(request: GroupDisableJoinLinkRequest): Response<GroupDisableJoinLinkResponse> =
+        toBlocking { disableJoinLink(request) }
+
+    override suspend fun getJoinLinkPreviews(
+        request: GroupGetJoinLinkPreviewsRequest
+    ): Response<GroupGetJoinLinkPreviewsResponse> {
+
+        return proceedGet(
+            BlueskyTypes.GroupGetJoinLinkPreviews,
+            request.toMap(),
+            request.auth,
+        )
+    }
+
+    override fun getJoinLinkPreviewsBlocking(request: GroupGetJoinLinkPreviewsRequest): Response<GroupGetJoinLinkPreviewsResponse> =
+        toBlocking { getJoinLinkPreviews(request) }
+
+    override suspend fun listMutualGroups(
+        request: GroupListMutualGroupsRequest
+    ): Response<GroupListMutualGroupsResponse> {
+
+        return proceedGet(
+            BlueskyTypes.GroupListMutualGroups,
+            request.toMap(),
+            request.auth,
+        )
+    }
+
+    override fun listMutualGroupsBlocking(request: GroupListMutualGroupsRequest): Response<GroupListMutualGroupsResponse> =
+        toBlocking { listMutualGroups(request) }
+
+    private suspend inline fun <reified T> proceedGet(
+        id: String,
+        queries: Map<String, Any>,
+        auth: AuthProvider,
+    ): Response<T> {
+        return proceed {
+            httpRequest(config)
+                .url(xrpc(config, id))
+                .header("Atproto-Proxy", "did:web:api.bsky.chat#bsky_chat")
+                .accept(MediaType.JSON)
+                .queries(queries)
+                .getWithAuth(auth)
+        }
+    }
+
+    private suspend inline fun <reified T> proceedPost(
+        id: String,
+        requestJson: String,
+        auth: AuthProvider,
+    ): Response<T> {
+        return proceed {
+            httpRequest(config)
+                .url(xrpc(config, id))
+                .header("Atproto-Proxy", "did:web:api.bsky.chat#bsky_chat")
+                .accept(MediaType.JSON)
+                .json(requestJson)
+                .postWithAuth(auth)
+        }
+    }
+
+    private suspend fun proceedPostUnit(
+        id: String,
+        requestJson: String,
+        auth: AuthProvider,
+    ): ResponseUnit {
+        return proceedUnit {
+            httpRequest(config)
+                .url(xrpc(config, id))
+                .header("Atproto-Proxy", "did:web:api.bsky.chat#bsky_chat")
+                .accept(MediaType.JSON)
+                .json(requestJson)
+                .postWithAuth(auth)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsDirectConvoMember.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsDirectConvoMember.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.model.chat.bsky.actor
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.actor.defs#directConvoMember
+ *
+ * Member of a 1-on-1 direct message (no fields)
+ */
+@Serializable
+@JsExport
+data class ActorDefsDirectConvoMember(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+) : ActorDefsProfileViewBasicKindUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ChatActorDefs + "#directConvoMember"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsGroupConvoMember.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsGroupConvoMember.kt
@@ -1,0 +1,26 @@
+package work.socialhub.kbsky.model.chat.bsky.actor
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.actor.defs#groupConvoMember
+ */
+@Serializable
+@JsExport
+data class ActorDefsGroupConvoMember(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    // chat.bsky.actor.defs#memberRole ("owner" / "standard")
+    val role: String,
+    // Only when the member was added rather than joining via a link
+    val addedBy: ActorDefsProfileViewBasic? = null,
+) : ActorDefsProfileViewBasicKindUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ChatActorDefs + "#groupConvoMember"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsPastGroupConvoMember.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsPastGroupConvoMember.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.model.chat.bsky.actor
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.actor.defs#pastGroupConvoMember
+ *
+ * Member who used to belong to the group (no fields)
+ */
+@Serializable
+@JsExport
+data class ActorDefsPastGroupConvoMember(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+) : ActorDefsProfileViewBasicKindUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ChatActorDefs + "#pastGroupConvoMember"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsProfileViewBasic.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsProfileViewBasic.kt
@@ -25,4 +25,6 @@ data class ActorDefsProfileViewBasic(
     var labels: List<LabelDefsLabel>? = null,
     var chatDisabled: Boolean = false,
     var verification: ActorDefsVerificationState? = null,
+    // Member kind in a conversation (direct / group / past-group)
+    var kind: ActorDefsProfileViewBasicKindUnion? = null,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsProfileViewBasicKindUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/actor/ActorDefsProfileViewBasicKindUnion.kt
@@ -1,0 +1,25 @@
+package work.socialhub.kbsky.model.chat.bsky.actor
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.util.json.ChatActorDefsProfileViewBasicKindUnionSerializer
+import kotlin.js.JsExport
+
+/**
+ * The kind field of chat.bsky.actor.defs#profileViewBasic
+ *
+ * @see ActorDefsDirectConvoMember
+ * @see ActorDefsGroupConvoMember
+ * @see ActorDefsPastGroupConvoMember
+ */
+@Serializable(with = ChatActorDefsProfileViewBasicKindUnionSerializer::class)
+@JsExport
+abstract class ActorDefsProfileViewBasicKindUnion {
+    @SerialName("\$type")
+    abstract val type: String
+
+    val asDirectConvoMember get() = this as? ActorDefsDirectConvoMember
+    val asGroupConvoMember get() = this as? ActorDefsGroupConvoMember
+    val asPastGroupConvoMember get() = this as? ActorDefsPastGroupConvoMember
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoKindUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoKindUnion.kt
@@ -1,0 +1,23 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.util.json.ChatConvoDefsConvoKindUnionSerializer
+import kotlin.js.JsExport
+
+/**
+ * The kind field of chat.bsky.convo.defs#convoView
+ *
+ * @see ConvoDefsGroupConvo
+ * @see ConvoDefsDirectConvo
+ */
+@Serializable(with = ChatConvoDefsConvoKindUnionSerializer::class)
+@JsExport
+abstract class ConvoDefsConvoKindUnion {
+    @SerialName("\$type")
+    abstract val type: String
+
+    val asGroupConvo get() = this as? ConvoDefsGroupConvo
+    val asDirectConvo get() = this as? ConvoDefsDirectConvo
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsConvoView.kt
@@ -13,9 +13,14 @@ import kotlin.js.JsExport
 data class ConvoDefsConvoView(
     val id: String,
     val rev: String,
+    // For groups, only the important members rather than all of them. Use getConvoMembers for the full list.
     val members: List<ActorDefsProfileViewBasic>,
     val lastMessage: ConvoDefsMessageUnion? = null,
     val lastReaction: ConvoDefsMessageAndReactionView? = null,
     val muted: Boolean = false,
+    // chat.bsky.convo.defs#convoStatus ("request" / "accepted"), viewer perspective, optional
+    val status: String? = null,
+    // Union identifying direct / group (optional)
+    val kind: ConvoDefsConvoKindUnion? = null,
     val unreadCount: Int = 0,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsDirectConvo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsDirectConvo.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#directConvo
+ *
+ * 1-on-1 direct message (no fields)
+ */
+@Serializable
+@JsExport
+data class ConvoDefsDirectConvo(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+) : ConvoDefsConvoKindUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#directConvo"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsGroupConvo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsGroupConvo.kt
@@ -1,0 +1,35 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkView
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#groupConvo
+ */
+@Serializable
+@JsExport
+data class ConvoDefsGroupConvo(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val createdAt: String,
+    // chat.bsky.convo.defs#convoLockStatus ("unlocked" / "locked" / "locked-permanently")
+    val lockStatus: String,
+    // Whether the lock was forced by moderation
+    val lockStatusModerationOverride: Boolean,
+    val memberCount: Int,
+    val memberLimit: Int,
+    val name: String,
+    val joinLink: GroupDefsJoinLinkView? = null,
+    // The following are available only to the owner
+    val joinRequestCount: Int? = null,
+    val unreadJoinRequestCount: Int? = null,
+) : ConvoDefsConvoKindUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#groupConvo"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageInput.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageInput.kt
@@ -12,6 +12,7 @@ data class ConvoDefsMessageInput(
     var text: String,
     var facets: List<RichtextFacet>? = null,
     var embed: EmbedUnion? = null,
-    // Reference to the message being replied to
-    var replyRef: ConvoDefsReplyRef? = null,
+    // Reference to the message being replied to.
+    // lexicon field name is "replyTo" (the referenced type is chat.bsky.convo.defs#replyRef).
+    var replyTo: ConvoDefsReplyRef? = null,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageInput.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageInput.kt
@@ -12,4 +12,6 @@ data class ConvoDefsMessageInput(
     var text: String,
     var facets: List<RichtextFacet>? = null,
     var embed: EmbedUnion? = null,
+    // Reference to the message being replied to
+    var replyRef: ConvoDefsReplyRef? = null,
 )

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageUnion.kt
@@ -9,6 +9,7 @@ import kotlin.js.JsExport
 /**
  * @see ConvoDefsMessageView
  * @see ConvoDefsDeletedMessageView
+ * @see ConvoDefsSystemMessageView
  */
 @Serializable(with = ChatConvoDefsMessageUnionSerializer::class)
 @JsExport
@@ -18,4 +19,5 @@ abstract class ConvoDefsMessageUnion {
 
     val asMessageView get() = this as? ConvoDefsMessageView
     val asDeletedMessageView get() = this as? ConvoDefsDeletedMessageView
+    val asSystemMessageView get() = this as? ConvoDefsSystemMessageView
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsMessageView.kt
@@ -21,6 +21,8 @@ data class ConvoDefsMessageView(
     val reactions: List<ConvoDefsReactionView> = emptyList(),
     val sender: ConvoDefsMessageViewSender,
     val sentAt: String,
+    // The message being replied to (expanded one level only). union [messageView, deletedMessageView]
+    val replyTo: ConvoDefsMessageUnion? = null,
 ) : ConvoDefsMessageUnion() {
 
     companion object {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsReplyRef.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsReplyRef.kt
@@ -1,0 +1,16 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#replyRef
+ *
+ * Reply reference to a message
+ */
+@Serializable
+@JsExport
+data class ConvoDefsReplyRef(
+    val messageId: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataAddMember.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataAddMember.kt
@@ -1,0 +1,26 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataAddMember
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataAddMember(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val member: ConvoDefsSystemMessageReferredUser,
+    // chat.bsky.actor.defs#memberRole ("owner" / "standard")
+    val role: String,
+    val addedBy: ConvoDefsSystemMessageReferredUser,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataAddMember"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataCreateJoinLink.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataCreateJoinLink.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataCreateJoinLink
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataCreateJoinLink(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataCreateJoinLink"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataDisableJoinLink.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataDisableJoinLink.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataDisableJoinLink
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataDisableJoinLink(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataDisableJoinLink"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataEditGroup.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataEditGroup.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataEditGroup
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataEditGroup(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val oldName: String? = null,
+    val newName: String? = null,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataEditGroup"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataEditJoinLink.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataEditJoinLink.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataEditJoinLink
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataEditJoinLink(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataEditJoinLink"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataEnableJoinLink.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataEnableJoinLink.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataEnableJoinLink
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataEnableJoinLink(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataEnableJoinLink"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataLockConvo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataLockConvo.kt
@@ -1,0 +1,23 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataLockConvo
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataLockConvo(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val lockedBy: ConvoDefsSystemMessageReferredUser,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataLockConvo"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataLockConvoPermanently.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataLockConvoPermanently.kt
@@ -1,0 +1,23 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataLockConvoPermanently
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataLockConvoPermanently(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val lockedBy: ConvoDefsSystemMessageReferredUser,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataLockConvoPermanently"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataMemberJoin.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataMemberJoin.kt
@@ -1,0 +1,27 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataMemberJoin
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataMemberJoin(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val member: ConvoDefsSystemMessageReferredUser,
+    // chat.bsky.actor.defs#memberRole ("owner" / "standard")
+    val role: String,
+    // Only when approval was required
+    val approvedBy: ConvoDefsSystemMessageReferredUser? = null,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataMemberJoin"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataMemberLeave.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataMemberLeave.kt
@@ -1,0 +1,23 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataMemberLeave
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataMemberLeave(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val member: ConvoDefsSystemMessageReferredUser,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataMemberLeave"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataRemoveMember.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataRemoveMember.kt
@@ -1,0 +1,24 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataRemoveMember
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataRemoveMember(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val member: ConvoDefsSystemMessageReferredUser,
+    val removedBy: ConvoDefsSystemMessageReferredUser,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataRemoveMember"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataUnion.kt
@@ -1,0 +1,30 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.util.json.ChatConvoDefsSystemMessageDataUnionSerializer
+import kotlin.js.JsExport
+
+/**
+ * The data field of chat.bsky.convo.defs#systemMessageView (12 variants)
+ */
+@Serializable(with = ChatConvoDefsSystemMessageDataUnionSerializer::class)
+@JsExport
+abstract class ConvoDefsSystemMessageDataUnion {
+    @SerialName("\$type")
+    abstract val type: String
+
+    val asAddMember get() = this as? ConvoDefsSystemMessageDataAddMember
+    val asRemoveMember get() = this as? ConvoDefsSystemMessageDataRemoveMember
+    val asMemberJoin get() = this as? ConvoDefsSystemMessageDataMemberJoin
+    val asMemberLeave get() = this as? ConvoDefsSystemMessageDataMemberLeave
+    val asLockConvo get() = this as? ConvoDefsSystemMessageDataLockConvo
+    val asUnlockConvo get() = this as? ConvoDefsSystemMessageDataUnlockConvo
+    val asLockConvoPermanently get() = this as? ConvoDefsSystemMessageDataLockConvoPermanently
+    val asEditGroup get() = this as? ConvoDefsSystemMessageDataEditGroup
+    val asCreateJoinLink get() = this as? ConvoDefsSystemMessageDataCreateJoinLink
+    val asEditJoinLink get() = this as? ConvoDefsSystemMessageDataEditJoinLink
+    val asEnableJoinLink get() = this as? ConvoDefsSystemMessageDataEnableJoinLink
+    val asDisableJoinLink get() = this as? ConvoDefsSystemMessageDataDisableJoinLink
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataUnlockConvo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageDataUnlockConvo.kt
@@ -1,0 +1,23 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageDataUnlockConvo
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageDataUnlockConvo(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val unlockedBy: ConvoDefsSystemMessageReferredUser,
+) : ConvoDefsSystemMessageDataUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageDataUnlockConvo"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageReferredUser.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageReferredUser.kt
@@ -1,0 +1,16 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageReferredUser
+ *
+ * Lightweight user reference (did only). Profiles are resolved via relatedProfiles in the log.
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageReferredUser(
+    val did: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/convo/ConvoDefsSystemMessageView.kt
@@ -1,0 +1,28 @@
+package work.socialhub.kbsky.model.chat.bsky.convo
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.convo.defs#systemMessageView
+ *
+ * Union member of convoView.lastMessage / getMessages
+ */
+@Serializable
+@JsExport
+data class ConvoDefsSystemMessageView(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val id: String,
+    val rev: String,
+    val sentAt: String,
+    val data: ConvoDefsSystemMessageDataUnion,
+) : ConvoDefsMessageUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.ConvoDefs + "#systemMessageView"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsDisabledJoinLinkPreviewView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsDisabledJoinLinkPreviewView.kt
@@ -1,0 +1,25 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.group.defs#disabledJoinLinkPreviewView
+ *
+ * For a disabled join link (code only)
+ */
+@Serializable
+@JsExport
+data class GroupDefsDisabledJoinLinkPreviewView(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val code: String,
+) : GroupDefsJoinLinkPreviewUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.GroupDefs + "#disabledJoinLinkPreviewView"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsInvalidJoinLinkPreviewView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsInvalidJoinLinkPreviewView.kt
@@ -1,0 +1,25 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.group.defs#invalidJoinLinkPreviewView
+ *
+ * For a non-existent code (code only)
+ */
+@Serializable
+@JsExport
+data class GroupDefsInvalidJoinLinkPreviewView(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val code: String,
+) : GroupDefsJoinLinkPreviewUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.GroupDefs + "#invalidJoinLinkPreviewView"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkPreviewUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkPreviewUnion.kt
@@ -1,0 +1,23 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.util.json.ChatGroupDefsJoinLinkPreviewUnionSerializer
+import kotlin.js.JsExport
+
+/**
+ * @see GroupDefsJoinLinkPreviewView
+ * @see GroupDefsDisabledJoinLinkPreviewView
+ * @see GroupDefsInvalidJoinLinkPreviewView
+ */
+@Serializable(with = ChatGroupDefsJoinLinkPreviewUnionSerializer::class)
+@JsExport
+abstract class GroupDefsJoinLinkPreviewUnion {
+    @SerialName("\$type")
+    abstract val type: String
+
+    val asJoinLinkPreviewView get() = this as? GroupDefsJoinLinkPreviewView
+    val asDisabledJoinLinkPreviewView get() = this as? GroupDefsDisabledJoinLinkPreviewView
+    val asInvalidJoinLinkPreviewView get() = this as? GroupDefsInvalidJoinLinkPreviewView
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkPreviewView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkPreviewView.kt
@@ -1,0 +1,36 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoView
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.group.defs#joinLinkPreviewView
+ */
+@Serializable
+@JsExport
+data class GroupDefsJoinLinkPreviewView(
+    @SerialName("\$type")
+    override val type: String = TYPE,
+    val convoId: String,
+    val code: String,
+    val name: String,
+    val owner: ActorDefsProfileViewBasic,
+    val memberCount: Int,
+    val memberLimit: Int,
+    val requireApproval: Boolean,
+    // chat.bsky.group.defs#joinRule ("anyone" / "followedByOwner")
+    val joinRule: String,
+    // Only when authenticated and a member
+    val convo: ConvoDefsConvoView? = null,
+    val viewer: GroupDefsJoinLinkViewerState? = null,
+) : GroupDefsJoinLinkPreviewUnion() {
+
+    companion object {
+        const val TYPE = BlueskyTypes.GroupDefs + "#joinLinkPreviewView"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkView.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.group.defs#joinLinkView
+ */
+@Serializable
+@JsExport
+data class GroupDefsJoinLinkView(
+    val code: String,
+    // chat.bsky.group.defs#linkEnabledStatus ("enabled" / "disabled")
+    val enabledStatus: String,
+    val requireApproval: Boolean,
+    // chat.bsky.group.defs#joinRule ("anyone" / "followedByOwner")
+    val joinRule: String,
+    val createdAt: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinLinkViewerState.kt
@@ -1,0 +1,14 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.group.defs#joinLinkViewerState
+ */
+@Serializable
+@JsExport
+data class GroupDefsJoinLinkViewerState(
+    val requestedAt: String? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinRequestConvoView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinRequestConvoView.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.group.defs#joinRequestConvoView
+ *
+ * Join request from the requester's perspective
+ */
+@Serializable
+@JsExport
+data class GroupDefsJoinRequestConvoView(
+    val convoId: String,
+    val name: String,
+    val owner: ActorDefsProfileViewBasic,
+    val memberCount: Int,
+    val memberLimit: Int,
+    val viewer: GroupDefsJoinLinkViewerState,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinRequestView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/chat/bsky/group/GroupDefsJoinRequestView.kt
@@ -1,0 +1,19 @@
+package work.socialhub.kbsky.model.chat.bsky.group
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasic
+import kotlin.js.JsExport
+
+/**
+ * chat.bsky.group.defs#joinRequestView
+ *
+ * Join request from the owner's perspective
+ */
+@Serializable
+@JsExport
+data class GroupDefsJoinRequestView(
+    val convoId: String,
+    val requestedBy: ActorDefsProfileViewBasic,
+    val requestedAt: String,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/AnySerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/AnySerializer.kt
@@ -106,7 +106,7 @@ object AnySerializer : KSerializer<Any> {
             // Each element is serialized recursively with AnySerializer.
             is List<*> -> encoder.encodeSerializableValue(
                 ListSerializer(AnySerializer),
-                value.map { it as Any },
+                value.filterNotNull(),
             )
 
             else -> {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/AnySerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/AnySerializer.kt
@@ -1,6 +1,7 @@
 package work.socialhub.kbsky.util.json
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
@@ -100,6 +101,13 @@ object AnySerializer : KSerializer<Any> {
 
             is RepoRef -> encoder.encodeSerializableValue(RepoRef.serializer(), value)
             is RepoStrongRef -> encoder.encodeSerializableValue(RepoStrongRef.serializer(), value)
+
+            // List values. Used for things like members (an array of dids) in createGroup/addMembers.
+            // Each element is serialized recursively with AnySerializer.
+            is List<*> -> encoder.encodeSerializableValue(
+                ListSerializer(AnySerializer),
+                value.map { it as Any },
+            )
 
             else -> {
                 println("Can't serialize unknown type: ${value::class}")

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatActorDefsProfileViewBasicKindUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatActorDefsProfileViewBasicKindUnionSerializer.kt
@@ -1,0 +1,36 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsDirectConvoMember
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsGroupConvoMember
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsPastGroupConvoMember
+import work.socialhub.kbsky.model.chat.bsky.actor.ActorDefsProfileViewBasicKindUnion
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object ChatActorDefsProfileViewBasicKindUnionSerializer :
+    JsonContentPolymorphicSerializer<ActorDefsProfileViewBasicKindUnion>(
+        ActorDefsProfileViewBasicKindUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<ActorDefsProfileViewBasicKindUnion> {
+        return when (val type = element.type()) {
+            ActorDefsDirectConvoMember.TYPE -> ActorDefsDirectConvoMember.serializer()
+            ActorDefsGroupConvoMember.TYPE -> ActorDefsGroupConvoMember.serializer()
+            ActorDefsPastGroupConvoMember.TYPE -> ActorDefsPastGroupConvoMember.serializer()
+            else -> {
+                println("[Warning] Unknown Item type: $type (ChatActorDefsProfileViewBasicKindUnion)")
+                Unknown.serializer()
+            }
+        }
+    }
+
+    @Serializable
+    class Unknown : ActorDefsProfileViewBasicKindUnion() {
+        override var type: String = "unknown"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsConvoKindUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsConvoKindUnionSerializer.kt
@@ -1,0 +1,34 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsConvoKindUnion
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsDirectConvo
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsGroupConvo
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object ChatConvoDefsConvoKindUnionSerializer :
+    JsonContentPolymorphicSerializer<ConvoDefsConvoKindUnion>(
+        ConvoDefsConvoKindUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<ConvoDefsConvoKindUnion> {
+        return when (val type = element.type()) {
+            ConvoDefsGroupConvo.TYPE -> ConvoDefsGroupConvo.serializer()
+            ConvoDefsDirectConvo.TYPE -> ConvoDefsDirectConvo.serializer()
+            else -> {
+                println("[Warning] Unknown Item type: $type (ChatConvoDefsConvoKindUnion)")
+                Unknown.serializer()
+            }
+        }
+    }
+
+    @Serializable
+    class Unknown : ConvoDefsConvoKindUnion() {
+        override var type: String = "unknown"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsMessageUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsMessageUnionSerializer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.JsonElement
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsDeletedMessageView
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageUnion
 import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsMessageView
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageView
 import work.socialhub.kbsky.util.json.JsonElementUtil.type
 
 object ChatConvoDefsMessageUnionSerializer :
@@ -20,6 +21,7 @@ object ChatConvoDefsMessageUnionSerializer :
         return when (val type = element.type()) {
             ConvoDefsMessageView.TYPE -> ConvoDefsMessageView.serializer()
             ConvoDefsDeletedMessageView.TYPE -> ConvoDefsDeletedMessageView.serializer()
+            ConvoDefsSystemMessageView.TYPE -> ConvoDefsSystemMessageView.serializer()
             else -> {
                 println("[Warning] Unknown Item type: $type (ChatConvoDefsMessageUnion)")
                 Unknown.serializer()

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsSystemMessageDataUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatConvoDefsSystemMessageDataUnionSerializer.kt
@@ -1,0 +1,54 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataAddMember
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataCreateJoinLink
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataDisableJoinLink
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataEditGroup
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataEditJoinLink
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataEnableJoinLink
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataLockConvo
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataLockConvoPermanently
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataMemberJoin
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataMemberLeave
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataRemoveMember
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataUnion
+import work.socialhub.kbsky.model.chat.bsky.convo.ConvoDefsSystemMessageDataUnlockConvo
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object ChatConvoDefsSystemMessageDataUnionSerializer :
+    JsonContentPolymorphicSerializer<ConvoDefsSystemMessageDataUnion>(
+        ConvoDefsSystemMessageDataUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<ConvoDefsSystemMessageDataUnion> {
+        return when (val type = element.type()) {
+            ConvoDefsSystemMessageDataAddMember.TYPE -> ConvoDefsSystemMessageDataAddMember.serializer()
+            ConvoDefsSystemMessageDataRemoveMember.TYPE -> ConvoDefsSystemMessageDataRemoveMember.serializer()
+            ConvoDefsSystemMessageDataMemberJoin.TYPE -> ConvoDefsSystemMessageDataMemberJoin.serializer()
+            ConvoDefsSystemMessageDataMemberLeave.TYPE -> ConvoDefsSystemMessageDataMemberLeave.serializer()
+            ConvoDefsSystemMessageDataLockConvo.TYPE -> ConvoDefsSystemMessageDataLockConvo.serializer()
+            ConvoDefsSystemMessageDataUnlockConvo.TYPE -> ConvoDefsSystemMessageDataUnlockConvo.serializer()
+            ConvoDefsSystemMessageDataLockConvoPermanently.TYPE -> ConvoDefsSystemMessageDataLockConvoPermanently.serializer()
+            ConvoDefsSystemMessageDataEditGroup.TYPE -> ConvoDefsSystemMessageDataEditGroup.serializer()
+            ConvoDefsSystemMessageDataCreateJoinLink.TYPE -> ConvoDefsSystemMessageDataCreateJoinLink.serializer()
+            ConvoDefsSystemMessageDataEditJoinLink.TYPE -> ConvoDefsSystemMessageDataEditJoinLink.serializer()
+            ConvoDefsSystemMessageDataEnableJoinLink.TYPE -> ConvoDefsSystemMessageDataEnableJoinLink.serializer()
+            ConvoDefsSystemMessageDataDisableJoinLink.TYPE -> ConvoDefsSystemMessageDataDisableJoinLink.serializer()
+            else -> {
+                println("[Warning] Unknown Item type: $type (ChatConvoDefsSystemMessageDataUnion)")
+                Unknown.serializer()
+            }
+        }
+    }
+
+    @Serializable
+    class Unknown : ConvoDefsSystemMessageDataUnion() {
+        override var type: String = "unknown"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatGroupDefsJoinLinkPreviewUnionSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/ChatGroupDefsJoinLinkPreviewUnionSerializer.kt
@@ -1,0 +1,36 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsDisabledJoinLinkPreviewView
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsInvalidJoinLinkPreviewView
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkPreviewUnion
+import work.socialhub.kbsky.model.chat.bsky.group.GroupDefsJoinLinkPreviewView
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object ChatGroupDefsJoinLinkPreviewUnionSerializer :
+    JsonContentPolymorphicSerializer<GroupDefsJoinLinkPreviewUnion>(
+        GroupDefsJoinLinkPreviewUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<GroupDefsJoinLinkPreviewUnion> {
+        return when (val type = element.type()) {
+            GroupDefsJoinLinkPreviewView.TYPE -> GroupDefsJoinLinkPreviewView.serializer()
+            GroupDefsDisabledJoinLinkPreviewView.TYPE -> GroupDefsDisabledJoinLinkPreviewView.serializer()
+            GroupDefsInvalidJoinLinkPreviewView.TYPE -> GroupDefsInvalidJoinLinkPreviewView.serializer()
+            else -> {
+                println("[Warning] Unknown Item type: $type (ChatGroupDefsJoinLinkPreviewUnion)")
+                Unknown.serializer()
+            }
+        }
+    }
+
+    @Serializable
+    class Unknown : GroupDefsJoinLinkPreviewUnion() {
+        override var type: String = "unknown"
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/group/GroupCreateGroupSerializeTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/chat/bsky/group/GroupCreateGroupSerializeTest.kt
@@ -1,0 +1,58 @@
+package work.socialhub.kbsky.chat.bsky.group
+
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupAddMembersRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupCreateGroupRequest
+import work.socialhub.kbsky.api.entity.chat.bsky.group.GroupRemoveMembersRequest
+import work.socialhub.kbsky.auth.BearerTokenAuthProvider
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Serialization test for chat.bsky.group POST requests.
+ *
+ * Verifies that a POST body containing members (an array of dids) is correctly emitted as a JSON array.
+ * (Detects the regression where members are dropped if AnySerializer cannot handle a List.)
+ * No network required.
+ */
+class GroupCreateGroupSerializeTest {
+
+    private val auth = BearerTokenAuthProvider("dummy-access-token")
+
+    @Test
+    fun testCreateGroupSerialize() {
+        val json = GroupCreateGroupRequest(
+            auth = auth,
+            members = listOf("did:plc:aaa", "did:plc:bbb"),
+            name = "My Group",
+        ).toMappedJson()
+
+        // members must be emitted as a JSON array (not stringified or dropped).
+        assertTrue(json.contains("\"members\""), json)
+        assertTrue(json.contains("[\"did:plc:aaa\",\"did:plc:bbb\"]"), json)
+        assertTrue(json.contains("\"name\":\"My Group\""), json)
+    }
+
+    @Test
+    fun testAddMembersSerialize() {
+        val json = GroupAddMembersRequest(
+            auth = auth,
+            convoId = "convo-1",
+            members = listOf("did:plc:ccc"),
+        ).toMappedJson()
+
+        assertTrue(json.contains("\"convoId\":\"convo-1\""), json)
+        assertTrue(json.contains("[\"did:plc:ccc\"]"), json)
+    }
+
+    @Test
+    fun testRemoveMembersSerialize() {
+        val json = GroupRemoveMembersRequest(
+            auth = auth,
+            convoId = "convo-1",
+            members = listOf("did:plc:ccc", "did:plc:ddd"),
+        ).toMappedJson()
+
+        assertTrue(json.contains("\"convoId\":\"convo-1\""), json)
+        assertTrue(json.contains("[\"did:plc:ccc\",\"did:plc:ddd\"]"), json)
+    }
+}


### PR DESCRIPTION
## Summary
- Add the `chat.bsky.group.*` namespace (16 methods) for group chat management and join flows
- Add 5 new `chat.bsky.convo.*` methods used by groups (`acceptConvo` / `lockConvo` / `unlockConvo` / `getConvoMembers` / `getConvoAvailability`)
- Extend the existing convo / actor models so that a group is represented as a kind of convo

## Background
Bluesky rolled out group chats in June 2026. A group chat is modeled as a **kind of convo** (`convoView.kind`, a union of `#directConvo` / `#groupConvo`) rather than a dedicated record type; `chat.bsky.group.*` provides the management / join-flow APIs on top of the existing `chat.bsky.convo.*`. The lexicons are still marked as under active development.

## Changes
- `BlueskyTypes.kt`: Add NSID constants for `chat.bsky.group.*` and the new convo methods
- models: `model/chat/bsky/group/*` (joinLink / joinLinkPreview union / joinRequest views); convo extensions (`kind` union with `groupConvo` / `directConvo`, `systemMessageView` + 12 system-message data union members + `referredUser`, `replyRef`); actor extensions (`profileViewBasic.kind` union of 3)
- serializers: 4 new `JsonContentPolymorphicSerializer` (convoKind / systemMessageData / joinLinkPreview / profileViewBasic.kind), plus a `systemMessageView` branch added to the existing message-union serializer
- entities: convo 10 + group 29 Request/Response
- resources: new `GroupResource` / `GroupResourceImpl` (16 methods); `ConvoResource` / `ConvoResourceImpl` extended (5 methods). Both reuse the `did:web:api.bsky.chat#bsky_chat` proxy header
- wiring: `Bluesky.group()` / `BlueskyImpl`
- `AnySerializer`: handle `List` values so that array fields in `Map<String, Any>` POST bodies (e.g. `members` in createGroup / addMembers / removeMembers) are serialized as JSON arrays

## Notes
- Group is a kind of convo: the core is the `ConvoDefsConvoView` extension (`kind` / `status`; the `lastMessage` union gains `systemMessageView`), and `chat.bsky.group.*` sits on top as the management API.
- Existing convo / actor models are extended non-destructively (nullable fields with defaults), preserving DM compatibility.
- `AnySerializer` previously had no `List` branch on the serialize side. The group requests are the first to put a raw `List` into a `Map<String, Any>` POST body, so a `List` branch was added (covered by an offline regression test).
- Intentionally deferred: `chat.bsky.embed.joinLink` (would require turning `messageView.embed` into a union — a breaking change) and `chat.bsky.convo.listConvoRequests` (heterogeneous union output without a `$type` base). The requestJoin / withdraw + listJoinRequests / approve / reject flow already covers join management.

## Test plan
- [x] `./gradlew :core:compileKotlinJvm` / `:core:compileTestKotlinJvm` compile without errors
- [x] `GroupCreateGroupSerializeTest` passes (`members` is emitted as a JSON array for createGroup / addMembers / removeMembers)
- [ ] createGroup / addMembers / requestJoin etc. work against a live server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added group chat management capabilities including group creation, member administration, and group settings.
  * Added group join request and join link management functionality.
  * Added conversation locking, unlocking, and availability checking features.
  * Added system message support for tracking group events and member changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->