### PR TITLE
Feat/embed video presentation

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideo.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideo.kt
@@ -20,6 +20,9 @@ data class EmbedVideo(
     // var captions: List<EmbedVideoCaption>? = null
     var alt: String? = null,
     var aspectRatio: EmbedDefsAspectRatio? = null,
+    // A hint to the client about how to present the video.
+    // knownValues: "default", "gif"
+    var presentation: String? = null,
 ) : EmbedUnion() {
 
     companion object {

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideoView.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/embed/EmbedVideoView.kt
@@ -17,6 +17,9 @@ data class EmbedVideoView(
     var thumbnail: String? = null,
     var alt: String? = null,
     var aspectRatio: EmbedDefsAspectRatio? = null,
+    // A hint to the client about how to present the video.
+    // knownValues: "default", "gif"
+    var presentation: String? = null,
 ) : EmbedViewUnion() {
 
     companion object {

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/embed/EmbedVideoTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/embed/EmbedVideoTest.kt
@@ -4,6 +4,7 @@ import work.socialhub.kbsky.internal.share.InternalUtility.fromJson
 import work.socialhub.kbsky.internal.share.InternalUtility.toJson
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedDefsAspectRatio
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedVideo
+import work.socialhub.kbsky.model.app.bsky.embed.EmbedVideoView
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedUnion
 import work.socialhub.kbsky.model.app.bsky.embed.EmbedViewUnion
 import work.socialhub.kbsky.model.share.Blob
@@ -22,13 +23,15 @@ class EmbedVideoTest {
 
     @Test
     fun testVideoSerialize() {
-        // Post side: serialize EmbedVideo and confirm $type and presentation are emitted.
+        // Post side: serialize EmbedVideo with every field populated and confirm
+        // $type and presentation are emitted.
         val video = EmbedVideo().also {
             it.video = Blob(
                 ref = BlobRef(link = "bafkreitestcid"),
                 mimeType = "video/mp4",
                 size = 29264,
             )
+            it.alt = "a looping clip"
             it.aspectRatio = EmbedDefsAspectRatio(2000, 1366)
             it.presentation = "gif"
         }
@@ -38,11 +41,19 @@ class EmbedVideoTest {
         assertTrue(json.contains("\"presentation\""), json)
         assertTrue(json.contains("\"gif\""), json)
 
-        // Confirm it round-trips as an EmbedUnion.
+        // Confirm every field round-trips as an EmbedUnion.
         val parsed = fromJson<EmbedUnion>(json)
         val asVideo = assertNotNull(parsed.asVideo)
+        assertEquals(EmbedVideo.TYPE, asVideo.type)
+        assertEquals("a looping clip", asVideo.alt)
         assertEquals("gif", asVideo.presentation)
-        assertEquals("video/mp4", asVideo.video?.mimeType)
+        assertEquals(2000, asVideo.aspectRatio?.width)
+        assertEquals(1366, asVideo.aspectRatio?.height)
+
+        val blob = assertNotNull(asVideo.video)
+        assertEquals("bafkreitestcid", blob.ref?.link)
+        assertEquals("video/mp4", blob.mimeType)
+        assertEquals(29264, blob.size)
     }
 
     @Test
@@ -55,6 +66,7 @@ class EmbedVideoTest {
               "cid": "bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4",
               "playlist": "https://video.bsky.app/watch/did%3Aplc%3Ahow3ikalqaaqkm4wbrkkzdew/bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4/playlist.m3u8",
               "thumbnail": "https://video.bsky.app/watch/did%3Aplc%3Ahow3ikalqaaqkm4wbrkkzdew/bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4/thumbnail.jpg",
+              "alt": "a looping clip",
               "presentation": "gif",
               "aspectRatio": { "width": 2000, "height": 1366 }
             }
@@ -63,9 +75,11 @@ class EmbedVideoTest {
         val view = fromJson<EmbedViewUnion>(json)
         val video = assertNotNull(view.asVideo)
 
+        assertEquals(EmbedVideoView.TYPE, video.type)
         assertEquals("bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4", video.cid)
         assertTrue(video.playlist.endsWith("playlist.m3u8"), video.playlist)
         assertTrue(video.thumbnail!!.endsWith("thumbnail.jpg"), video.thumbnail!!)
+        assertEquals("a looping clip", video.alt)
         assertEquals("gif", video.presentation)
         assertEquals(2000, video.aspectRatio?.width)
         assertEquals(1366, video.aspectRatio?.height)
@@ -73,7 +87,8 @@ class EmbedVideoTest {
 
     @Test
     fun testVideoViewDeserialize_noPresentation() {
-        // A regular (non-GIF) video has no presentation hint -> stays null.
+        // A regular (non-GIF) video omits every optional field -> they stay null,
+        // while the required cid/playlist are still populated.
         val json = """
             {
               "${'$'}type": "app.bsky.embed.video#view",
@@ -84,6 +99,11 @@ class EmbedVideoTest {
 
         val view = fromJson<EmbedViewUnion>(json)
         val video = assertNotNull(view.asVideo)
+        assertEquals("bafkreiregularvideo", video.cid)
+        assertTrue(video.playlist.endsWith("playlist.m3u8"), video.playlist)
+        assertEquals(null, video.thumbnail)
+        assertEquals(null, video.alt)
+        assertEquals(null, video.aspectRatio)
         assertEquals(null, video.presentation)
     }
 }

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/embed/EmbedVideoTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/embed/EmbedVideoTest.kt
@@ -1,0 +1,89 @@
+package work.socialhub.kbsky.app.bsky.embed
+
+import work.socialhub.kbsky.internal.share.InternalUtility.fromJson
+import work.socialhub.kbsky.internal.share.InternalUtility.toJson
+import work.socialhub.kbsky.model.app.bsky.embed.EmbedDefsAspectRatio
+import work.socialhub.kbsky.model.app.bsky.embed.EmbedVideo
+import work.socialhub.kbsky.model.app.bsky.embed.EmbedUnion
+import work.socialhub.kbsky.model.app.bsky.embed.EmbedViewUnion
+import work.socialhub.kbsky.model.share.Blob
+import work.socialhub.kbsky.model.share.BlobRef
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Serialization/deserialization tests for app.bsky.embed.video.
+ * Covers the "presentation" hint (default/gif) used for GIF-style videos.
+ * No network required.
+ */
+class EmbedVideoTest {
+
+    @Test
+    fun testVideoSerialize() {
+        // Post side: serialize EmbedVideo and confirm $type and presentation are emitted.
+        val video = EmbedVideo().also {
+            it.video = Blob(
+                ref = BlobRef(link = "bafkreitestcid"),
+                mimeType = "video/mp4",
+                size = 29264,
+            )
+            it.aspectRatio = EmbedDefsAspectRatio(2000, 1366)
+            it.presentation = "gif"
+        }
+
+        val json = toJson(video)
+        assertTrue(json.contains("\"app.bsky.embed.video\""), json)
+        assertTrue(json.contains("\"presentation\""), json)
+        assertTrue(json.contains("\"gif\""), json)
+
+        // Confirm it round-trips as an EmbedUnion.
+        val parsed = fromJson<EmbedUnion>(json)
+        val asVideo = assertNotNull(parsed.asVideo)
+        assertEquals("gif", asVideo.presentation)
+        assertEquals("video/mp4", asVideo.video?.mimeType)
+    }
+
+    @Test
+    fun testVideoViewDeserialize() {
+        // Read side: real getPostThread response for a GIF post.
+        // (https://bsky.app/profile/tmy.bsky.social/post/3mpdelk4i5s2h)
+        val json = """
+            {
+              "${'$'}type": "app.bsky.embed.video#view",
+              "cid": "bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4",
+              "playlist": "https://video.bsky.app/watch/did%3Aplc%3Ahow3ikalqaaqkm4wbrkkzdew/bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4/playlist.m3u8",
+              "thumbnail": "https://video.bsky.app/watch/did%3Aplc%3Ahow3ikalqaaqkm4wbrkkzdew/bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4/thumbnail.jpg",
+              "presentation": "gif",
+              "aspectRatio": { "width": 2000, "height": 1366 }
+            }
+        """.trimIndent()
+
+        val view = fromJson<EmbedViewUnion>(json)
+        val video = assertNotNull(view.asVideo)
+
+        assertEquals("bafkreic5fq22qdgrqklnhcrhd64ptbqm272vuppxjxqn3t2ddtyfaf6dr4", video.cid)
+        assertTrue(video.playlist.endsWith("playlist.m3u8"), video.playlist)
+        assertTrue(video.thumbnail!!.endsWith("thumbnail.jpg"), video.thumbnail!!)
+        assertEquals("gif", video.presentation)
+        assertEquals(2000, video.aspectRatio?.width)
+        assertEquals(1366, video.aspectRatio?.height)
+    }
+
+    @Test
+    fun testVideoViewDeserialize_noPresentation() {
+        // A regular (non-GIF) video has no presentation hint -> stays null.
+        val json = """
+            {
+              "${'$'}type": "app.bsky.embed.video#view",
+              "cid": "bafkreiregularvideo",
+              "playlist": "https://video.bsky.app/watch/did%3Aplc%3Atest/bafkreiregularvideo/playlist.m3u8"
+            }
+        """.trimIndent()
+
+        val view = fromJson<EmbedViewUnion>(json)
+        val video = assertNotNull(view.asVideo)
+        assertEquals(null, video.presentation)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional video presentation hint to video embed data, supporting client display modes such as standard and GIF-style playback.
  * Video views can now surface this presentation setting when available.

* **Tests**
  * Added coverage for video serialization and deserialization, including cases with and without the presentation value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->