### PR TITLE
Add app.bsky.feed.searchPostsV2 support

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -45,6 +45,7 @@ object BlueskyTypes {
     const val FeedGetActorFeeds = "app.bsky.feed.getActorFeeds"
     const val FeedGetActorLikes = "app.bsky.feed.getActorLikes"
     const val FeedGetFeedSearchPosts = "app.bsky.feed.searchPosts"
+    const val FeedSearchPostsV2 = "app.bsky.feed.searchPostsV2"
     const val FeedGetFeedGenerator = "app.bsky.feed.getFeedGenerator"
     const val FeedGetFeedGenerators = "app.bsky.feed.getFeedGenerators"
     const val FeedGetSuggestedFeeds = "app.bsky.feed.getSuggestedFeeds"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/FeedResource.kt
@@ -46,6 +46,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedRepostRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedRepostResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsV2Request
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsV2Response
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedThreadgateRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedThreadgateResponse
 import work.socialhub.kbsky.api.entity.share.Response
@@ -202,6 +204,18 @@ interface FeedResource {
     fun searchPostsBlocking(
         request: FeedSearchPostsRequest
     ): Response<FeedSearchPostsResponse>
+
+    /**
+     * Find posts matching a search query or filters, returning search hits for matching post records.
+     */
+    suspend fun searchPostsV2(
+        request: FeedSearchPostsV2Request
+    ): Response<FeedSearchPostsV2Response>
+
+    @JsExport.Ignore
+    fun searchPostsV2Blocking(
+        request: FeedSearchPostsV2Request
+    ): Response<FeedSearchPostsV2Response>
 
     /**
      * Get information about a specific feed offered by a feed generator, such as its online status.

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsRequest.kt
@@ -11,6 +11,8 @@ data class FeedSearchPostsRequest(
     override val auth: AuthProvider,
     /** Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. */
     var q: String,
+    /** Specifies the ranking order of results. ("top" or "latest", default: "latest") */
+    var sort: String? = null,
     // [1-100] default: 25
     var limit: Int? = null,
     /** Optional pagination mechanism; may not necessarily allow scrolling through entire result set. */
@@ -20,6 +22,7 @@ data class FeedSearchPostsRequest(
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {
             it.addParam("q", q)
+            it.addParam("sort", sort)
             it.addParam("limit", limit)
             it.addParam("cursor", cursor)
         }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsV2Request.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsV2Request.kt
@@ -1,0 +1,126 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class FeedSearchPostsV2Request(
+    override val auth: AuthProvider,
+    /** Search query string. A query or at least one filter is required. */
+    var query: String? = null,
+    /** Ranking order for results. 'recent' sorts by recency; 'top' uses search ranking. */
+    var sort: String? = null,
+    /** Include posts by any of these authors (at-identifier). Handles are resolved to DIDs before searching. */
+    var authors: List<String>? = null,
+    /** Include posts that mention any of these accounts (at-identifier). */
+    var mentions: List<String>? = null,
+    /** Include posts that link to any of these domains. */
+    var domains: List<String>? = null,
+    /** Include posts that link to any of these URLs. */
+    var urls: List<String>? = null,
+    /** Include posts that embed any of these AT URIs. */
+    var embeddedAtUris: List<String>? = null,
+    /** Include posts tagged with any of these hashtags. Do not include the hash (#) prefix. */
+    var hashtags: List<String>? = null,
+    /** Exclude posts by any of these authors (at-identifier). */
+    var excludeAuthors: List<String>? = null,
+    /** Exclude posts that mention any of these accounts (at-identifier). */
+    var excludeMentions: List<String>? = null,
+    /** Exclude posts that link to any of these domains. */
+    var excludeDomains: List<String>? = null,
+    /** Exclude posts that link to any of these URLs. */
+    var excludeUrls: List<String>? = null,
+    /** Exclude posts that embed any of these AT URIs. */
+    var excludeEmbeddedAtUris: List<String>? = null,
+    /** Exclude posts tagged with any of these hashtags. Do not include the hash (#) prefix. */
+    var excludeHashtags: List<String>? = null,
+    /** Include posts indexed at or after this timestamp. Can be a datetime, or just an ISO date (YYYY-MM-DD). */
+    var since: String? = null,
+    /** Include posts indexed before this timestamp. Defaults to the current time. */
+    var until: String? = null,
+    /** Search the full index instead of the recent-post window. */
+    var allTime: Boolean? = null,
+    /** Include posts whose language matches any of these language codes. */
+    var languages: List<String>? = null,
+    /** Exclude posts whose language matches any of these language codes. */
+    var excludeLanguages: List<String>? = null,
+    /** Include only posts with media. */
+    var hasMedia: Boolean? = null,
+    /** Include only posts with video. */
+    var hasVideo: Boolean? = null,
+    /** Include only direct replies to this parent post URI. */
+    var replyParentUri: String? = null,
+    /** Include only posts in the thread rooted at this post URI. */
+    var threadRootUri: String? = null,
+    /** Exclude replies from results. Mutually exclusive with repliesOnly. */
+    var excludeReplies: Boolean? = null,
+    /** Include only replies. Mutually exclusive with excludeReplies. */
+    var repliesOnly: Boolean? = null,
+    /** Include only posts from accounts followed by the viewer. */
+    var following: Boolean? = null,
+    /** Language analyzer hint for the query text ("ja", "zh", "ko", "th", "ar"). If unset, the server auto-detects when possible. */
+    var queryLanguage: String? = null,
+    // [1-100] default: 25
+    var limit: Int? = null,
+    /** Optional pagination cursor. */
+    var cursor: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    /** Scalar parameters only. Array parameters are provided by [toListParams]. */
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("query", query)
+            it.addParam("sort", sort)
+            it.addParam("since", since)
+            it.addParam("until", until)
+            it.addParam("allTime", allTime)
+            it.addParam("hasMedia", hasMedia)
+            it.addParam("hasVideo", hasVideo)
+            it.addParam("replyParentUri", replyParentUri)
+            it.addParam("threadRootUri", threadRootUri)
+            it.addParam("excludeReplies", excludeReplies)
+            it.addParam("repliesOnly", repliesOnly)
+            it.addParam("following", following)
+            it.addParam("queryLanguage", queryLanguage)
+            it.addParam("limit", limit)
+            it.addParam("cursor", cursor)
+        }
+    }
+
+    /**
+     * Array parameters. These must be expanded as `key=v1&key=v2` on the query string,
+     * so they are kept out of [toMap] (khttpclient's `queries(Map)` calls `toString()`
+     * on List values, producing `"[v1, v2]"`).
+     */
+    fun toListParams(): Map<String, List<String>> {
+        return mutableMapOf<String, List<String>>().also {
+            it.addListParam("authors", authors)
+            it.addListParam("mentions", mentions)
+            it.addListParam("domains", domains)
+            it.addListParam("urls", urls)
+            it.addListParam("embeddedAtUris", embeddedAtUris)
+            it.addListParam("hashtags", hashtags)
+            it.addListParam("excludeAuthors", excludeAuthors)
+            it.addListParam("excludeMentions", excludeMentions)
+            it.addListParam("excludeDomains", excludeDomains)
+            it.addListParam("excludeUrls", excludeUrls)
+            it.addListParam("excludeEmbeddedAtUris", excludeEmbeddedAtUris)
+            it.addListParam("excludeHashtags", excludeHashtags)
+            it.addListParam("languages", languages)
+            it.addListParam("excludeLanguages", excludeLanguages)
+        }
+    }
+
+    private fun MutableMap<String, List<String>>.addListParam(
+        key: String,
+        values: List<String>?
+    ) {
+        if (values.isNullOrEmpty()) {
+            return
+        }
+        this[key] = values
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsV2Response.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/feed/FeedSearchPostsV2Response.kt
@@ -1,0 +1,22 @@
+package work.socialhub.kbsky.api.entity.app.bsky.feed
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class FeedSearchPostsV2Response(
+    /** Cursor for the next page of results. */
+    var cursor: String? = null,
+
+    /** Estimated total number of matching hits. May be rounded or truncated. */
+    var hitsTotal: Int? = null,
+
+    /** Hydrated views of matching posts. */
+    var posts: List<FeedDefsPostView> = emptyList(),
+
+    /** Query languages detected for CJK, Thai, or Arabic text ("ja", "zh", "ko", "th", "ar"). Empty or omitted for other scripts. */
+    var detectedQueryLanguages: List<String>? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/FeedResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/FeedResourceImpl.kt
@@ -21,6 +21,7 @@ import work.socialhub.kbsky.BlueskyTypes.FeedGetQuotes
 import work.socialhub.kbsky.BlueskyTypes.FeedGetRepostedBy
 import work.socialhub.kbsky.BlueskyTypes.FeedGetSuggestedFeeds
 import work.socialhub.kbsky.BlueskyTypes.FeedGetTimeline
+import work.socialhub.kbsky.BlueskyTypes.FeedSearchPostsV2
 import work.socialhub.kbsky.BlueskyTypes.FeedLike
 import work.socialhub.kbsky.BlueskyTypes.FeedPost
 import work.socialhub.kbsky.BlueskyTypes.FeedPostgate
@@ -72,6 +73,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedRepostRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedRepostResponse
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsResponse
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsV2Request
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsV2Response
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedThreadgateRequest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedThreadgateResponse
 import work.socialhub.kbsky.api.entity.com.atproto.repo.RepoCreateRecordRequest
@@ -345,6 +348,34 @@ class FeedResourceImpl(
     ): Response<FeedSearchPostsResponse> {
         return toBlocking {
             searchPosts(request)
+        }
+    }
+
+    override suspend fun searchPostsV2(
+        request: FeedSearchPostsV2Request
+    ): Response<FeedSearchPostsV2Response> {
+
+        return proceed {
+            httpRequest(config)
+                .url(xrpc(config, FeedSearchPostsV2))
+                .accept(MediaType.JSON)
+                .queries(request.toMap())
+                .also { req ->
+                    // Array parameters must be expanded as key=v1&key=v2,
+                    // so they take a dedicated path that calls query() for each element.
+                    request.toListParams().forEach { (key, values) ->
+                        values.forEach { req.query(key, it) }
+                    }
+                }
+                .getWithAuth(request.auth)
+        }
+    }
+
+    override fun searchPostsV2Blocking(
+        request: FeedSearchPostsV2Request
+    ): Response<FeedSearchPostsV2Response> {
+        return toBlocking {
+            searchPostsV2(request)
         }
     }
 

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/feed/SearchPostsV2Test.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/feed/SearchPostsV2Test.kt
@@ -3,7 +3,13 @@ package work.socialhub.kbsky.app.bsky.feed
 import kotlinx.coroutines.test.runTest
 import work.socialhub.kbsky.AbstractTest
 import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsV2Request
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsV2Response
+import work.socialhub.kbsky.internal.share.InternalUtility.fromJson
+import work.socialhub.kbsky.internal.share.InternalUtility.toJson
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class SearchPostsV2Test : AbstractTest() {
 
@@ -19,8 +25,25 @@ class SearchPostsV2Test : AbstractTest() {
                 )
             )
 
-        feeds.data.posts
-            .forEach { print(it) }
+        val data = assertNotNull(feeds.data)
+        // 検索結果は posts か次ページの cursor のいずれかを含むこと
+        assertTrue(
+            data.posts.isNotEmpty() || data.cursor != null,
+            "posts と cursor の両方が空です。"
+        )
+        data.posts.forEach { post ->
+            assertTrue(assertNotNull(post.uri).startsWith("at://"), "uri: ${post.uri}")
+            assertTrue(assertNotNull(post.cid).isNotEmpty(), "cid が空です。")
+            assertTrue(assertNotNull(post.author?.did).isNotEmpty(), "author.did が空です。")
+            assertNotNull(post.record, "record がありません。")
+        }
+
+        // レスポンス全体がシリアライズ/デシリアライズで往復できること
+        val restored = fromJson<FeedSearchPostsV2Response>(toJson(data))
+        assertEquals(data.cursor, restored.cursor)
+        assertEquals(data.hitsTotal, restored.hitsTotal)
+        assertEquals(data.detectedQueryLanguages, restored.detectedQueryLanguages)
+        assertEquals(data.posts.map { it.uri }, restored.posts.map { it.uri })
     }
 
     @Test
@@ -38,9 +61,95 @@ class SearchPostsV2Test : AbstractTest() {
                 )
             )
 
-        println("hitsTotal: ${feeds.data.hitsTotal}")
-        println("detectedQueryLanguages: ${feeds.data.detectedQueryLanguages}")
-        feeds.data.posts
-            .forEach { print(it) }
+        val data = assertNotNull(feeds.data)
+        assertTrue(
+            data.posts.isNotEmpty() || data.cursor != null,
+            "posts と cursor の両方が空です。"
+        )
+        data.hitsTotal?.let { assertTrue(it >= 0, "hitsTotal: $it") }
+        data.posts.forEach { post ->
+            assertNotNull(post.uri)
+            assertNotNull(post.cid)
+        }
+
+        println("hitsTotal: ${data.hitsTotal}")
+        println("detectedQueryLanguages: ${data.detectedQueryLanguages}")
+    }
+
+    @Test
+    fun testRequestParameterMapping() {
+        // テストで使用するリクエストフィールドがクエリパラメータへ正しく変換されること
+        val request = FeedSearchPostsV2Request(
+            auth = auth(),
+            query = "kotlin",
+            sort = "top",
+            languages = listOf("ja", "en"),
+            hasMedia = true,
+            allTime = true,
+        )
+
+        val params = request.toMap()
+        assertEquals("kotlin", params["query"])
+        assertEquals("top", params["sort"])
+        assertEquals(true, params["hasMedia"])
+        assertEquals(true, params["allTime"])
+        // 未指定のスカラーパラメータは含まれないこと
+        assertTrue("limit" !in params)
+        assertTrue("cursor" !in params)
+        // 配列パラメータは toMap ではなく toListParams 側で展開されること
+        assertTrue("languages" !in params)
+
+        val listParams = request.toListParams()
+        assertEquals(listOf("ja", "en"), listParams["languages"])
+        // 未指定の配列パラメータは含まれないこと
+        assertTrue("authors" !in listParams)
+    }
+
+    @Test
+    fun testResponseDeserialize() {
+        // レスポンスの全フィールドがデシリアライズされること(ネットワーク不要)
+        val json = """
+            {
+              "cursor": "25",
+              "hitsTotal": 100,
+              "detectedQueryLanguages": ["ja"],
+              "posts": [
+                {
+                  "uri": "at://did:plc:example/app.bsky.feed.post/abc123",
+                  "cid": "bafyreiexample",
+                  "author": {
+                    "did": "did:plc:example",
+                    "handle": "example.bsky.social"
+                  },
+                  "record": {
+                    "${'$'}type": "app.bsky.feed.post",
+                    "text": "hello",
+                    "createdAt": "2024-01-01T00:00:00.000Z"
+                  },
+                  "replyCount": 1,
+                  "repostCount": 2,
+                  "likeCount": 3,
+                  "indexedAt": "2024-01-01T00:00:00.000Z"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val response = fromJson<FeedSearchPostsV2Response>(json)
+        assertEquals("25", response.cursor)
+        assertEquals(100, response.hitsTotal)
+        assertEquals(listOf("ja"), response.detectedQueryLanguages)
+        assertEquals(1, response.posts.size)
+
+        val post = response.posts[0]
+        assertEquals("at://did:plc:example/app.bsky.feed.post/abc123", post.uri)
+        assertEquals("bafyreiexample", post.cid)
+        assertEquals("did:plc:example", post.author?.did)
+        assertEquals("example.bsky.social", post.author?.handle)
+        assertEquals("hello", post.record?.asFeedPost?.text)
+        assertEquals(1, post.replyCount)
+        assertEquals(2, post.repostCount)
+        assertEquals(3, post.likeCount)
+        assertEquals("2024-01-01T00:00:00.000Z", post.indexedAt)
     }
 }

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/feed/SearchPostsV2Test.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/feed/SearchPostsV2Test.kt
@@ -1,0 +1,46 @@
+package work.socialhub.kbsky.app.bsky.feed
+
+import kotlinx.coroutines.test.runTest
+import work.socialhub.kbsky.AbstractTest
+import work.socialhub.kbsky.api.entity.app.bsky.feed.FeedSearchPostsV2Request
+import kotlin.test.Test
+
+class SearchPostsV2Test : AbstractTest() {
+
+    @Test
+    fun testSearchPostsV2() = runTest {
+        val feeds = client()
+            .feed()
+            .searchPostsV2(
+                FeedSearchPostsV2Request(
+                    auth = auth(),
+                    query = "SocialHub",
+                    sort = "recent",
+                )
+            )
+
+        feeds.data.posts
+            .forEach { print(it) }
+    }
+
+    @Test
+    fun testSearchPostsV2WithFilters() = runTest {
+        val feeds = client()
+            .feed()
+            .searchPostsV2(
+                FeedSearchPostsV2Request(
+                    auth = auth(),
+                    query = "kotlin",
+                    sort = "top",
+                    languages = listOf("ja", "en"),
+                    hasMedia = true,
+                    allTime = true,
+                )
+            )
+
+        println("hitsTotal: ${feeds.data.hitsTotal}")
+        println("detectedQueryLanguages: ${feeds.data.detectedQueryLanguages}")
+        feeds.data.posts
+            .forEach { print(it) }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `app.bsky.feed.searchPostsV2`, the enhanced post search endpoint with rich filtering (authors / mentions / domains / hashtags / languages / media / reply scope, etc.)
- Add the `sort` parameter to the existing v1 `searchPosts` request as well

## Background
Bluesky introduced `searchPostsV2`, which extends the v1 `searchPosts` with many include/exclude filters, time-range options (`since` / `until` / `allTime`), thread scoping (`replyParentUri` / `threadRootUri`), and viewer-relative filtering (`following`). This endpoint was not yet implemented in kbsky. The v1 request was also missing the `sort` parameter, which is added in the same commit.

## Changes
- `BlueskyTypes.kt`: Add NSID constant `FeedSearchPostsV2`
- `FeedResource.kt` / `FeedResourceImpl.kt`: Add `searchPostsV2` / `searchPostsV2Blocking`
- Add `FeedSearchPostsV2Request` (query / sort / include & exclude filters for authors, mentions, domains, urls, embeddedAtUris, hashtags / since / until / allTime / languages / hasMedia / hasVideo / replyParentUri / threadRootUri / excludeReplies / repliesOnly / following / queryLanguage / limit / cursor)
- Add `FeedSearchPostsV2Response` (`cursor` / `hitsTotal` / `posts: List<FeedDefsPostView>` / `detectedQueryLanguages`)
- `FeedSearchPostsRequest.kt` (v1): Add the `sort` parameter ("top" or "latest")

## Notes
Array parameters must be expanded as `key=v1&key=v2` on the query string, but khttpclient's `queries(Map)` calls `toString()` on List values (producing `"[v1, v2]"`). The request therefore separates scalar parameters (`toMap()`) from array parameters (`toListParams()`), and the impl calls `query(key, value)` for each array element.

## Test plan
- [x] `./gradlew :core:compileKotlinJvm` / `:core:compileTestKotlinJvm` compile without errors
- [x] `searchPostsV2` returns results against a live server (`SearchPostsV2Test`)
- [x] Array filters (e.g. `languages`) are expanded correctly as repeated query parameters

↑ZonePaneの開発版としてざっくり疎通は通しています。全パラメータのチェックまでは数が多くて出来てないですが、問題があれば随時直していきたいです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for searching posts through the Search Posts V2 endpoint.
  - Search supports sorting, date ranges, language and media filters, reply/thread options, author/content filters, and pagination.
  - Results now include matching posts, estimated total hits, continuation cursors, and detected query languages.
  - Existing post search now supports optional sorting by **top** or **latest**.
- **Tests**
  - Added/expanded JVM integration and serialization/deserialization tests for Search Posts V2, including request parameter mapping coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->