### PR TITLE
Add scoped mute (onlyReposts / onlyQuoteposts) support

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphMuteActorRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/graph/GraphMuteActorRequest.kt
@@ -10,11 +10,24 @@ import kotlin.js.JsExport
 data class GraphMuteActorRequest(
     override val auth: AuthProvider,
     var actor: String? = null,
+    /**
+     * Restrict the mute to the account's reposts.
+     * When any 'only' scope is set, just the scoped content is muted;
+     * when none are set, the account is fully muted.
+     * Repeat calls replace the stored scope rather than adding to it.
+     */
+    var onlyReposts: Boolean? = null,
+    /**
+     * Restrict the mute to the account's quote posts. See [onlyReposts].
+     */
+    var onlyQuoteposts: Boolean? = null,
 ) : AuthRequest(auth), MapRequest {
 
     override fun toMap(): Map<String, Any> {
         return mutableMapOf<String, Any>().also {
             it.addParam("actor", actor)
+            it.addParam("onlyReposts", onlyReposts)
+            it.addParam("onlyQuoteposts", onlyQuoteposts)
         }
     }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsViewerState.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/actor/ActorDefsViewerState.kt
@@ -8,6 +8,16 @@ import kotlin.js.JsExport
 @JsExport
 data class ActorDefsViewerState(
     var muted: Boolean? = null,
+    /**
+     * Whether the account's reposts are muted.
+     * Scoped mutes are exclusive with [muted]: this can be true while [muted] is false.
+     * If [muted] is true, this will be false.
+     */
+    var mutedOnlyReposts: Boolean? = null,
+    /**
+     * Whether the account's quote posts are muted. See [mutedOnlyReposts].
+     */
+    var mutedOnlyQuoteposts: Boolean? = null,
     var blockedBy: Boolean? = null,
     /** at-uri  */
     var blocking: String? = null,

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/MuteTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/graph/MuteTest.kt
@@ -2,8 +2,16 @@ package work.socialhub.kbsky.app.bsky.graph
 
 import kotlinx.coroutines.test.runTest
 import work.socialhub.kbsky.AbstractTest
+import work.socialhub.kbsky.api.entity.app.bsky.actor.ActorGetProfileRequest
 import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphMuteActorRequest
+import work.socialhub.kbsky.api.entity.app.bsky.graph.GraphUnmuteActorRequest
+import work.socialhub.kbsky.internal.share.InternalUtility.fromJson
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsViewerState
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class MuteTest : AbstractTest() {
 
@@ -25,6 +33,181 @@ class MuteTest : AbstractTest() {
             .muteActor(
                 GraphMuteActorRequest(auth()).also {
                     it.actor = "did:plc:oc6vwdlmk2kqyida5i74d3p5"
+                }
+            )
+    }
+
+    @Test
+    fun testMuteOnlyReposts() = runTest {
+        val actor = "bsky.app"
+
+        try {
+            client()
+                .graph()
+                .muteActor(
+                    GraphMuteActorRequest(auth()).also {
+                        it.actor = actor
+                        it.onlyReposts = true
+                    }
+                )
+
+            val viewer = getViewerState(actor)
+            println("viewer: $viewer")
+
+            // スコープ付きミュートは muted と排他であること
+            assertEquals(true, viewer.mutedOnlyReposts)
+            assertFalse(viewer.muted == true, "muted: ${viewer.muted}")
+            assertFalse(viewer.mutedOnlyQuoteposts == true)
+
+        } finally {
+            unmute(actor)
+        }
+    }
+
+    @Test
+    fun testMuteOnlyQuoteposts() = runTest {
+        val actor = "bsky.app"
+
+        try {
+            client()
+                .graph()
+                .muteActor(
+                    GraphMuteActorRequest(auth()).also {
+                        it.actor = actor
+                        it.onlyQuoteposts = true
+                    }
+                )
+
+            val viewer = getViewerState(actor)
+            println("viewer: $viewer")
+
+            assertEquals(true, viewer.mutedOnlyQuoteposts)
+            assertFalse(viewer.muted == true, "muted: ${viewer.muted}")
+            assertFalse(viewer.mutedOnlyReposts == true)
+
+        } finally {
+            unmute(actor)
+        }
+    }
+
+    @Test
+    fun testMuteScopeIsReplacedByRepeatCall() = runTest {
+        val actor = "bsky.app"
+
+        try {
+            // 1回目: リポストのみをミュート
+            client()
+                .graph()
+                .muteActor(
+                    GraphMuteActorRequest(auth()).also {
+                        it.actor = actor
+                        it.onlyReposts = true
+                    }
+                )
+
+            // 2回目: 引用ポストのみをミュート (スコープは追加ではなく置換される)
+            client()
+                .graph()
+                .muteActor(
+                    GraphMuteActorRequest(auth()).also {
+                        it.actor = actor
+                        it.onlyQuoteposts = true
+                    }
+                )
+
+            val viewer = getViewerState(actor)
+            println("viewer: $viewer")
+
+            assertEquals(true, viewer.mutedOnlyQuoteposts)
+            assertFalse(viewer.mutedOnlyReposts == true, "スコープが置換されていません。")
+
+        } finally {
+            unmute(actor)
+        }
+    }
+
+    @Test
+    fun testRequestParameterMapping() {
+        // スコープ指定がリクエストボディへ正しく変換されること (ネットワーク不要)
+        val request = GraphMuteActorRequest(auth()).also {
+            it.actor = "bsky.app"
+            it.onlyReposts = true
+            it.onlyQuoteposts = false
+        }
+
+        val params = request.toMap()
+        assertEquals("bsky.app", params["actor"])
+        assertEquals(true, params["onlyReposts"])
+        assertEquals(false, params["onlyQuoteposts"])
+
+        // Boolean が JSON のリテラルとして出力されること
+        val json = request.toMappedJson()
+        assertTrue(json.contains("\"onlyReposts\":true"), "json: $json")
+        assertTrue(json.contains("\"onlyQuoteposts\":false"), "json: $json")
+    }
+
+    @Test
+    fun testRequestParameterMappingWithoutScope() {
+        // スコープ未指定の場合はアカウント全体のミュートとしてキーが含まれないこと
+        val request = GraphMuteActorRequest(auth()).also {
+            it.actor = "bsky.app"
+        }
+
+        val params = request.toMap()
+        assertEquals("bsky.app", params["actor"])
+        assertTrue("onlyReposts" !in params)
+        assertTrue("onlyQuoteposts" !in params)
+    }
+
+    @Test
+    fun testViewerStateDeserialize() {
+        // スコープ付きミュートの状態がデシリアライズされること (ネットワーク不要)
+        val json = """
+            {
+              "muted": false,
+              "mutedOnlyReposts": true,
+              "mutedOnlyQuoteposts": false,
+              "blockedBy": false
+            }
+        """.trimIndent()
+
+        val viewer = fromJson<ActorDefsViewerState>(json)
+        assertEquals(false, viewer.muted)
+        assertEquals(true, viewer.mutedOnlyReposts)
+        assertEquals(false, viewer.mutedOnlyQuoteposts)
+        assertEquals(false, viewer.blockedBy)
+    }
+
+    @Test
+    fun testViewerStateDeserializeWithoutScope() {
+        // スコープ関連のフィールドが無いレスポンスでも壊れないこと
+        val viewer = fromJson<ActorDefsViewerState>("""{"muted": true}""")
+        assertEquals(true, viewer.muted)
+        assertEquals(null, viewer.mutedOnlyReposts)
+        assertEquals(null, viewer.mutedOnlyQuoteposts)
+    }
+
+    private suspend fun getViewerState(
+        actor: String
+    ): ActorDefsViewerState {
+        val profile = client()
+            .actor()
+            .getProfile(
+                ActorGetProfileRequest(auth()).also {
+                    it.actor = actor
+                }
+            )
+        return assertNotNull(profile.data.viewer, "viewer がありません。")
+    }
+
+    private suspend fun unmute(
+        actor: String
+    ) {
+        client()
+            .graph()
+            .unmuteActor(
+                GraphUnmuteActorRequest(auth()).also {
+                    it.actor = actor
                 }
             )
     }


### PR DESCRIPTION
## Summary
- Add the `onlyReposts` / `onlyQuoteposts` scope parameters to `app.bsky.graph.muteActor`
- Add the corresponding `mutedOnlyReposts` / `mutedOnlyQuoteposts` fields to `app.bsky.actor.defs#viewerState`

## Background
Bluesky extended `app.bsky.graph.muteActor` so that a mute can be restricted to a specific kind of content instead of muting the account entirely. When any `only` scope is set, just the scoped content is muted; when none are set, the account is fully muted. Repeat calls **replace** the stored scope rather than adding to it.

The read side is exposed through `viewerState`, where the scoped flags are exclusive with `muted` (`muted` is false while a scoped mute is in effect). Neither side was implemented in kbsky, so scoped mutes could not be created and existing scoped mutes were invisible to clients.

## Changes
- `GraphMuteActorRequest.kt`: Add `onlyReposts: Boolean?` / `onlyQuoteposts: Boolean?` and map them in `toMap()`
- `ActorDefsViewerState.kt`: Add `mutedOnlyReposts: Boolean?` / `mutedOnlyQuoteposts: Boolean?`
- `MuteTest.kt`: Add offline request-mapping / deserialization tests and live scoped-mute tests

## Notes
- The new `viewerState` fields are placed right after `muted` to follow the order in the lexicon. Note that this shifts the positional parameters (and `componentN()`) of the following fields; let me know if appending them at the end is preferred for compatibility.
- `AnySerializer` already handles `Boolean`, so the new parameters are emitted as JSON boolean literals in the POST body without any serializer change.
- Scope keys are omitted entirely when unset (`addParam` skips nulls), which is what makes the request a full-account mute.

## Test plan
- [x] `./gradlew :core:compileKotlinJvm` / `:core:compileTestKotlinJvm` compile without errors
- [x] Offline tests pass: request mapping (`onlyReposts` / `onlyQuoteposts` are emitted as JSON booleans; omitted when unset) and `viewerState` deserialization (with and without the scoped fields)
- [ ] Scoped mute works against a live server: `muteActor` with `onlyReposts` sets `mutedOnlyReposts` in `getProfile`'s `viewer` while `muted` stays false
- [ ] A repeat call with a different scope replaces the stored scope rather than adding to it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for muting an actor’s reposts only or quote posts only.
  * Added viewer-state indicators showing whether scoped repost or quote-post muting is active.
  * Added documented behavior for replacing existing scoped mute settings.

* **Bug Fixes**
  * Improved handling and representation of scoped mute settings in requests and viewer state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->