### PR TITLE
Add app.bsky.unspecced.getPostThreadV2 support

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/BlueskyTypes.kt
@@ -88,8 +88,10 @@ object BlueskyTypes {
     const val RichtextFacet = "app.bsky.richtext.facet"
 
     // Unspecced
+    const val UnspeccedDefs = "app.bsky.unspecced.defs"
     const val UnspeccedGetPopular = "app.bsky.unspecced.getPopular"
     const val UnspeccedGetPopularFeedGenerators = "app.bsky.unspecced.getPopularFeedGenerators"
+    const val UnspeccedGetPostThreadV2 = "app.bsky.unspecced.getPostThreadV2"
 
     // Video
     const val VideoGetJobStatus = "app.bsky.video.getJobStatus"

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/UnspeccedResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/app/bsky/UnspeccedResource.kt
@@ -5,6 +5,8 @@ import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFee
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFeedGeneratorsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularRequest
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularResponse
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPostThreadV2Request
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPostThreadV2Response
 import work.socialhub.kbsky.api.entity.share.Response
 import kotlin.js.JsExport
 
@@ -36,4 +38,17 @@ interface UnspeccedResource {
     fun getPopularFeedGeneratorsBlocking(
         request: UnspeccedGetPopularFeedGeneratorsRequest
     ): Response<UnspeccedGetPopularFeedGeneratorsResponse>
+
+    /**
+     * (NOTE: this endpoint is under development and WILL change without notice. Inputs and outputs are not stable.) Get posts in a thread. It is based in an anchor post at any depth of the tree, and returns posts above it (recursively resolving the parent, without further branching to their replies) and below it (recursive resolution of the replies, branching to their replies). Does not require auth, but additional metadata and filtering will be applied for authed requests.
+     */
+    @JsExport.Ignore
+    suspend fun getPostThreadV2(
+        request: UnspeccedGetPostThreadV2Request
+    ): Response<UnspeccedGetPostThreadV2Response>
+
+    @JsExport.Ignore
+    fun getPostThreadV2Blocking(
+        request: UnspeccedGetPostThreadV2Request
+    ): Response<UnspeccedGetPostThreadV2Response>
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPostThreadV2Request.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPostThreadV2Request.kt
@@ -1,0 +1,28 @@
+package work.socialhub.kbsky.api.entity.app.bsky.unspecced
+
+
+import work.socialhub.kbsky.api.entity.share.AuthRequest
+import work.socialhub.kbsky.api.entity.share.MapRequest
+import work.socialhub.kbsky.auth.AuthProvider
+import kotlin.js.JsExport
+
+@JsExport
+data class UnspeccedGetPostThreadV2Request(
+    override val auth: AuthProvider,
+    var anchor: String = "",
+    var above: Boolean? = null,
+    var below: Int? = null,
+    var branchingFactor: Int? = null,
+    var sort: String? = null,
+) : AuthRequest(auth), MapRequest {
+
+    override fun toMap(): Map<String, Any> {
+        return mutableMapOf<String, Any>().also {
+            it.addParam("anchor", anchor)
+            it.addParam("above", above)
+            it.addParam("below", below)
+            it.addParam("branchingFactor", branchingFactor)
+            it.addParam("sort", sort)
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPostThreadV2Response.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/api/entity/app/bsky/unspecced/UnspeccedGetPostThreadV2Response.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.api.entity.app.bsky.unspecced
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsThreadgateView
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItem
+import kotlin.js.JsExport
+
+/**
+ * Response for a post thread (v2) request.
+ */
+@Serializable
+@JsExport
+data class UnspeccedGetPostThreadV2Response(
+    var thread: List<UnspeccedDefsThreadItem> = emptyList(),
+    var threadgate: FeedDefsThreadgateView? = null,
+    var hasOtherReplies: Boolean = false,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/UnspeccedResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/internal/app/bsky/UnspeccedResourceImpl.kt
@@ -3,11 +3,14 @@ package work.socialhub.kbsky.internal.app.bsky
 import work.socialhub.kbsky.BlueskyConfig
 import work.socialhub.kbsky.BlueskyTypes.UnspeccedGetPopular
 import work.socialhub.kbsky.BlueskyTypes.UnspeccedGetPopularFeedGenerators
+import work.socialhub.kbsky.BlueskyTypes.UnspeccedGetPostThreadV2
 import work.socialhub.kbsky.api.app.bsky.UnspeccedResource
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFeedGeneratorsRequest
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularFeedGeneratorsResponse
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularRequest
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPopularResponse
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPostThreadV2Request
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPostThreadV2Response
 import work.socialhub.kbsky.api.entity.share.Response
 import work.socialhub.kbsky.internal.share.InternalUtility.getWithAuth
 import work.socialhub.kbsky.internal.share.InternalUtility.httpRequest
@@ -53,4 +56,21 @@ class UnspeccedResourceImpl(
     override fun getPopularFeedGeneratorsBlocking(
         request: UnspeccedGetPopularFeedGeneratorsRequest
     ): Response<UnspeccedGetPopularFeedGeneratorsResponse> = toBlocking { getPopularFeedGenerators(request) }
+
+    override suspend fun getPostThreadV2(
+        request: UnspeccedGetPostThreadV2Request
+    ): Response<UnspeccedGetPostThreadV2Response> {
+
+        return proceed {
+            httpRequest(config)
+                .url(xrpc(config, UnspeccedGetPostThreadV2))
+                .accept(MediaType.JSON)
+                .queries(request.toMap())
+                .getWithAuth(request.auth)
+        }
+    }
+
+    override fun getPostThreadV2Blocking(
+        request: UnspeccedGetPostThreadV2Request
+    ): Response<UnspeccedGetPostThreadV2Response> = toBlocking { getPostThreadV2(request) }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsBlockedAuthor.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/feed/FeedDefsBlockedAuthor.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.model.app.bsky.feed
+
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.model.app.bsky.actor.ActorDefsViewerState
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class FeedDefsBlockedAuthor(
+    var did: String = "",
+    var viewer: ActorDefsViewerState? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItem.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItem.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kbsky.model.app.bsky.unspecced
+
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class UnspeccedDefsThreadItem(
+    var uri: String = "",
+    var depth: Int = 0,
+    var value: UnspeccedDefsThreadItemUnion? = null,
+)

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemBlocked.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemBlocked.kt
@@ -1,0 +1,20 @@
+package work.socialhub.kbsky.model.app.bsky.unspecced
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsBlockedAuthor
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class UnspeccedDefsThreadItemBlocked(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var author: FeedDefsBlockedAuthor? = null,
+) : UnspeccedDefsThreadItemUnion() {
+    companion object {
+        val TYPE = BlueskyTypes.UnspeccedDefs + "#threadItemBlocked"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemNoUnauthenticated.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemNoUnauthenticated.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.model.app.bsky.unspecced
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class UnspeccedDefsThreadItemNoUnauthenticated(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+) : UnspeccedDefsThreadItemUnion() {
+    companion object {
+        val TYPE = BlueskyTypes.UnspeccedDefs + "#threadItemNoUnauthenticated"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemNotFound.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemNotFound.kt
@@ -1,0 +1,18 @@
+package work.socialhub.kbsky.model.app.bsky.unspecced
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class UnspeccedDefsThreadItemNotFound(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+) : UnspeccedDefsThreadItemUnion() {
+    companion object {
+        val TYPE = BlueskyTypes.UnspeccedDefs + "#threadItemNotFound"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemPost.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemPost.kt
@@ -1,0 +1,36 @@
+package work.socialhub.kbsky.model.app.bsky.unspecced
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.BlueskyTypes
+import work.socialhub.kbsky.model.app.bsky.feed.FeedDefsPostView
+import kotlin.js.JsExport
+
+@Serializable
+@JsExport
+data class UnspeccedDefsThreadItemPost(
+    @SerialName("\$type")
+    override var type: String = TYPE,
+    var post: FeedDefsPostView? = null,
+    var moreParents: Boolean = false,
+    var moreReplies: Int = 0,
+    /**
+     * This post is part of a contiguous thread by the OP from the thread root.
+     */
+    var opThread: Boolean = false,
+    /**
+     * The 1-indexed position of this post within the contiguous OP thread.
+     */
+    var opThreadPostIndex: Int? = null,
+    /**
+     * The total number of posts in the contiguous OP thread that this post belongs to.
+     */
+    var opThreadPostCount: Int? = null,
+    var hiddenByThreadgate: Boolean = false,
+    var mutedByViewer: Boolean = false,
+) : UnspeccedDefsThreadItemUnion() {
+    companion object {
+        val TYPE = BlueskyTypes.UnspeccedDefs + "#threadItemPost"
+    }
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemUnion.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/model/app/bsky/unspecced/UnspeccedDefsThreadItemUnion.kt
@@ -1,0 +1,25 @@
+package work.socialhub.kbsky.model.app.bsky.unspecced
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import work.socialhub.kbsky.util.json.UnspeccedDefsThreadItemPolymorphicSerializer
+import kotlin.js.JsExport
+
+/**
+ * @see UnspeccedDefsThreadItemPost
+ * @see UnspeccedDefsThreadItemNoUnauthenticated
+ * @see UnspeccedDefsThreadItemNotFound
+ * @see UnspeccedDefsThreadItemBlocked
+ */
+@Serializable(with = UnspeccedDefsThreadItemPolymorphicSerializer::class)
+@JsExport
+abstract class UnspeccedDefsThreadItemUnion {
+    @SerialName("\$type")
+    abstract var type: String
+
+    val asPost get() = this as? UnspeccedDefsThreadItemPost
+    val asNoUnauthenticated get() = this as? UnspeccedDefsThreadItemNoUnauthenticated
+    val asNotFound get() = this as? UnspeccedDefsThreadItemNotFound
+    val asBlocked get() = this as? UnspeccedDefsThreadItemBlocked
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/UnspeccedDefsThreadItemPolymorphicSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kbsky/util/json/UnspeccedDefsThreadItemPolymorphicSerializer.kt
@@ -1,0 +1,38 @@
+package work.socialhub.kbsky.util.json
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemBlocked
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemNoUnauthenticated
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemNotFound
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemPost
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemUnion
+import work.socialhub.kbsky.util.json.JsonElementUtil.type
+
+object UnspeccedDefsThreadItemPolymorphicSerializer :
+    JsonContentPolymorphicSerializer<UnspeccedDefsThreadItemUnion>(
+        UnspeccedDefsThreadItemUnion::class
+    ) {
+
+    override fun selectDeserializer(
+        element: JsonElement
+    ): DeserializationStrategy<UnspeccedDefsThreadItemUnion> {
+        return when (val type = element.type()) {
+            UnspeccedDefsThreadItemPost.TYPE -> UnspeccedDefsThreadItemPost.serializer()
+            UnspeccedDefsThreadItemNoUnauthenticated.TYPE -> UnspeccedDefsThreadItemNoUnauthenticated.serializer()
+            UnspeccedDefsThreadItemNotFound.TYPE -> UnspeccedDefsThreadItemNotFound.serializer()
+            UnspeccedDefsThreadItemBlocked.TYPE -> UnspeccedDefsThreadItemBlocked.serializer()
+            else -> {
+                println("[Warning] Unknown Item type: $type (UnspeccedDefsThreadItemUnion)")
+                Unknown.serializer()
+            }
+        }
+    }
+
+    @Serializable
+    class Unknown : UnspeccedDefsThreadItemUnion() {
+        override var type: String = "unknown"
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/unspecced/GetPostThreadV2Test.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/unspecced/GetPostThreadV2Test.kt
@@ -1,0 +1,35 @@
+package work.socialhub.kbsky.app.bsky.unspecced
+
+import kotlinx.coroutines.test.runTest
+import work.socialhub.kbsky.AbstractTest
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPostThreadV2Request
+import kotlin.test.Test
+
+class GetPostThreadV2Test : AbstractTest() {
+
+    @Test
+    fun testGetPostThreadV2() = runTest {
+        val anchor = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3mtwf7gxkwc2r"
+
+        val response = client()
+            .unspecced()
+            .getPostThreadV2(
+                UnspeccedGetPostThreadV2Request(auth()).also {
+                    it.anchor = anchor
+                }
+            )
+
+        println("hasOtherReplies: " + response.data.hasOtherReplies)
+
+        response.data.thread.forEach { item ->
+            val post = item.value?.asPost
+            println(
+                "depth=" + item.depth +
+                        ", uri=" + item.uri +
+                        ", opThread=" + post?.opThread +
+                        ", opThreadPostIndex=" + post?.opThreadPostIndex +
+                        ", opThreadPostCount=" + post?.opThreadPostCount
+            )
+        }
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/unspecced/GetPostThreadV2Test.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kbsky/app/bsky/unspecced/GetPostThreadV2Test.kt
@@ -3,12 +3,26 @@ package work.socialhub.kbsky.app.bsky.unspecced
 import kotlinx.coroutines.test.runTest
 import work.socialhub.kbsky.AbstractTest
 import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPostThreadV2Request
+import work.socialhub.kbsky.api.entity.app.bsky.unspecced.UnspeccedGetPostThreadV2Response
+import work.socialhub.kbsky.internal.share.InternalUtility.fromJson
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemBlocked
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemNoUnauthenticated
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemNotFound
+import work.socialhub.kbsky.model.app.bsky.unspecced.UnspeccedDefsThreadItemPost
+import work.socialhub.kbsky.util.json.UnspeccedDefsThreadItemPolymorphicSerializer
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class GetPostThreadV2Test : AbstractTest() {
 
     @Test
     fun testGetPostThreadV2() = runTest {
+        // The first post of a contiguous OP thread by bsky.app
         val anchor = "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.post/3mtwf7gxkwc2r"
 
         val response = client()
@@ -21,7 +35,22 @@ class GetPostThreadV2Test : AbstractTest() {
 
         println("hasOtherReplies: " + response.data.hasOtherReplies)
 
-        response.data.thread.forEach { item ->
+        val thread = response.data.thread
+        assertTrue(thread.isNotEmpty(), "thread is empty.")
+
+        // The first item must be the anchor itself
+        val first = thread.first()
+        assertEquals(anchor, first.uri)
+        assertEquals(0, first.depth)
+        val firstPost = assertNotNull(first.value?.asPost, "the first item is not a threadItemPost.")
+        assertEquals(anchor, firstPost.post?.uri)
+
+        // OP thread metadata must be populated
+        assertTrue(firstPost.opThread, "the first item is not part of the OP thread.")
+        assertEquals(1, firstPost.opThreadPostIndex)
+        assertNotNull(firstPost.opThreadPostCount)
+
+        thread.forEach { item ->
             val post = item.value?.asPost
             println(
                 "depth=" + item.depth +
@@ -30,6 +59,213 @@ class GetPostThreadV2Test : AbstractTest() {
                         ", opThreadPostIndex=" + post?.opThreadPostIndex +
                         ", opThreadPostCount=" + post?.opThreadPostCount
             )
+
+            // Every item must have a uri and a value
+            assertTrue(item.uri.startsWith("at://"), "uri: ${item.uri}")
+            assertNotNull(item.value, "value is missing: ${item.uri}")
+
+            // OP thread posts carry index / count; other posts do not
+            if (post != null) {
+                if (post.opThread) {
+                    assertNotNull(post.opThreadPostIndex, "opThreadPostIndex is missing: ${item.uri}")
+                    assertNotNull(post.opThreadPostCount, "opThreadPostCount is missing: ${item.uri}")
+                } else {
+                    assertNull(post.opThreadPostIndex, "opThreadPostIndex is unexpectedly present: ${item.uri}")
+                    assertNull(post.opThreadPostCount, "opThreadPostCount is unexpectedly present: ${item.uri}")
+                }
+            }
         }
+    }
+
+    @Test
+    fun testResponseDeserialize() {
+        // A response containing every threadItem variant deserializes correctly (no network required)
+        val json = """
+            {
+              "thread": [
+                {
+                  "uri": "at://did:plc:op/app.bsky.feed.post/root",
+                  "depth": 0,
+                  "value": {
+                    "${'$'}type": "app.bsky.unspecced.defs#threadItemPost",
+                    "post": {
+                      "${'$'}type": "app.bsky.feed.defs#postView",
+                      "uri": "at://did:plc:op/app.bsky.feed.post/root",
+                      "cid": "bafyroot",
+                      "author": { "did": "did:plc:op", "handle": "op.example.com" },
+                      "record": { "${'$'}type": "app.bsky.feed.post", "text": "root", "createdAt": "2026-09-01T00:00:00.000Z" },
+                      "replyCount": 3,
+                      "indexedAt": "2026-09-01T00:00:00.000Z"
+                    },
+                    "moreParents": false,
+                    "moreReplies": 2,
+                    "opThread": true,
+                    "opThreadPostIndex": 1,
+                    "opThreadPostCount": 3,
+                    "hiddenByThreadgate": false,
+                    "mutedByViewer": false
+                  }
+                },
+                {
+                  "uri": "at://did:plc:other/app.bsky.feed.post/reply",
+                  "depth": 1,
+                  "value": {
+                    "${'$'}type": "app.bsky.unspecced.defs#threadItemPost",
+                    "post": {
+                      "${'$'}type": "app.bsky.feed.defs#postView",
+                      "uri": "at://did:plc:other/app.bsky.feed.post/reply",
+                      "cid": "bafyreply",
+                      "author": { "did": "did:plc:other", "handle": "other.example.com" },
+                      "record": { "${'$'}type": "app.bsky.feed.post", "text": "reply", "createdAt": "2026-09-01T00:01:00.000Z" },
+                      "indexedAt": "2026-09-01T00:01:00.000Z"
+                    },
+                    "moreParents": false,
+                    "moreReplies": 0,
+                    "opThread": false,
+                    "hiddenByThreadgate": true,
+                    "mutedByViewer": true
+                  }
+                },
+                {
+                  "uri": "at://did:plc:blocked/app.bsky.feed.post/blocked",
+                  "depth": 1,
+                  "value": {
+                    "${'$'}type": "app.bsky.unspecced.defs#threadItemBlocked",
+                    "author": {
+                      "did": "did:plc:blocked",
+                      "viewer": { "blockedBy": true }
+                    }
+                  }
+                },
+                {
+                  "uri": "at://did:plc:gone/app.bsky.feed.post/gone",
+                  "depth": 1,
+                  "value": { "${'$'}type": "app.bsky.unspecced.defs#threadItemNotFound" }
+                },
+                {
+                  "uri": "at://did:plc:private/app.bsky.feed.post/private",
+                  "depth": 1,
+                  "value": { "${'$'}type": "app.bsky.unspecced.defs#threadItemNoUnauthenticated" }
+                },
+                {
+                  "uri": "at://did:plc:future/app.bsky.feed.post/future",
+                  "depth": 1,
+                  "value": { "${'$'}type": "app.bsky.unspecced.defs#threadItemSomethingNew" }
+                }
+              ],
+              "threadgate": {
+                "uri": "at://did:plc:op/app.bsky.feed.threadgate/root",
+                "cid": "bafygate"
+              },
+              "hasOtherReplies": true
+            }
+        """.trimIndent()
+
+        val response = fromJson<UnspeccedGetPostThreadV2Response>(json)
+
+        assertEquals(true, response.hasOtherReplies)
+        assertEquals("at://did:plc:op/app.bsky.feed.threadgate/root", response.threadgate?.uri)
+        assertEquals(6, response.thread.size)
+
+        // threadItemPost (part of the OP thread)
+        val root = response.thread[0]
+        assertEquals("at://did:plc:op/app.bsky.feed.post/root", root.uri)
+        assertEquals(0, root.depth)
+        val rootPost = assertIs<UnspeccedDefsThreadItemPost>(root.value)
+        assertEquals(UnspeccedDefsThreadItemPost.TYPE, rootPost.type)
+        assertEquals("at://did:plc:op/app.bsky.feed.post/root", rootPost.post?.uri)
+        assertEquals("op.example.com", rootPost.post?.author?.handle)
+        assertEquals(3, rootPost.post?.replyCount)
+        assertFalse(rootPost.moreParents)
+        assertEquals(2, rootPost.moreReplies)
+        assertTrue(rootPost.opThread)
+        assertEquals(1, rootPost.opThreadPostIndex)
+        assertEquals(3, rootPost.opThreadPostCount)
+        assertFalse(rootPost.hiddenByThreadgate)
+        assertFalse(rootPost.mutedByViewer)
+        // union accessors
+        assertNotNull(root.value?.asPost)
+        assertNull(root.value?.asBlocked)
+        assertNull(root.value?.asNotFound)
+        assertNull(root.value?.asNoUnauthenticated)
+
+        // threadItemPost (a reply that is not part of the OP thread)
+        val reply = response.thread[1]
+        assertEquals(1, reply.depth)
+        val replyPost = assertNotNull(reply.value?.asPost)
+        assertFalse(replyPost.opThread)
+        assertNull(replyPost.opThreadPostIndex)
+        assertNull(replyPost.opThreadPostCount)
+        assertEquals(0, replyPost.moreReplies)
+        assertTrue(replyPost.hiddenByThreadgate)
+        assertTrue(replyPost.mutedByViewer)
+
+        // threadItemBlocked
+        val blocked = assertIs<UnspeccedDefsThreadItemBlocked>(response.thread[2].value)
+        assertEquals(UnspeccedDefsThreadItemBlocked.TYPE, blocked.type)
+        assertEquals("did:plc:blocked", blocked.author?.did)
+        assertEquals(true, blocked.author?.viewer?.blockedBy)
+        assertNotNull(response.thread[2].value?.asBlocked)
+        assertNull(response.thread[2].value?.asPost)
+
+        // threadItemNotFound
+        val notFound = assertIs<UnspeccedDefsThreadItemNotFound>(response.thread[3].value)
+        assertEquals(UnspeccedDefsThreadItemNotFound.TYPE, notFound.type)
+        assertNotNull(response.thread[3].value?.asNotFound)
+
+        // threadItemNoUnauthenticated
+        val noAuth = assertIs<UnspeccedDefsThreadItemNoUnauthenticated>(response.thread[4].value)
+        assertEquals(UnspeccedDefsThreadItemNoUnauthenticated.TYPE, noAuth.type)
+        assertNotNull(response.thread[4].value?.asNoUnauthenticated)
+
+        // An unknown ${'$'}type falls back to Unknown without breaking the other items
+        val unknown = assertIs<UnspeccedDefsThreadItemPolymorphicSerializer.Unknown>(response.thread[5].value)
+        assertEquals("at://did:plc:future/app.bsky.feed.post/future", response.thread[5].uri)
+        assertNull(unknown.asPost)
+        assertNull(unknown.asBlocked)
+        assertNull(unknown.asNotFound)
+        assertNull(unknown.asNoUnauthenticated)
+    }
+
+    @Test
+    fun testResponseDeserializeMinimal() {
+        // A response without threadgate or OP thread fields still deserializes
+        val json = """
+            {
+              "thread": [
+                {
+                  "uri": "at://did:plc:op/app.bsky.feed.post/root",
+                  "depth": 0,
+                  "value": {
+                    "${'$'}type": "app.bsky.unspecced.defs#threadItemPost",
+                    "post": {
+                      "${'$'}type": "app.bsky.feed.defs#postView",
+                      "uri": "at://did:plc:op/app.bsky.feed.post/root",
+                      "cid": "bafyroot",
+                      "author": { "did": "did:plc:op", "handle": "op.example.com" },
+                      "record": { "${'$'}type": "app.bsky.feed.post", "text": "root", "createdAt": "2026-09-01T00:00:00.000Z" },
+                      "indexedAt": "2026-09-01T00:00:00.000Z"
+                    },
+                    "moreParents": false,
+                    "moreReplies": 0,
+                    "opThread": false,
+                    "hiddenByThreadgate": false,
+                    "mutedByViewer": false
+                  }
+                }
+              ],
+              "hasOtherReplies": false
+            }
+        """.trimIndent()
+
+        val response = fromJson<UnspeccedGetPostThreadV2Response>(json)
+
+        assertEquals(false, response.hasOtherReplies)
+        assertNull(response.threadgate)
+        assertEquals(1, response.thread.size)
+        val post = assertNotNull(response.thread[0].value?.asPost)
+        assertFalse(post.opThread)
+        assertNull(post.opThreadPostIndex)
+        assertNull(post.opThreadPostCount)
     }
 }


### PR DESCRIPTION
## Summary
- Add `app.bsky.unspecced.getPostThreadV2`, the flattened thread endpoint used by the official Bluesky client
- Add the `app.bsky.unspecced.defs#threadItem*` models (post / noUnauthenticated / notFound / blocked) as a `$type`-discriminated union

## Background
`getPostThreadV2` returns a thread as a **flat list of `threadItem`s** (each with `uri` / `depth` / `value`) instead of the recursive `threadViewPost` tree used by `app.bsky.feed.getPostThread`. It also exposes thread metadata that v1 does not, such as `opThread` / `opThreadPostIndex` / `opThreadPostCount` (contiguous OP thread), `moreParents` / `moreReplies`, `hiddenByThreadgate` / `mutedByViewer`, and the response-level `hasOtherReplies`. Note that the lexicon is explicitly marked as unspecced and may change without notice.

## Changes
- `BlueskyTypes.kt`: Add NSID constants `UnspeccedDefs` / `UnspeccedGetPostThreadV2`
- `UnspeccedResource.kt` / `UnspeccedResourceImpl.kt`: Add `getPostThreadV2` / `getPostThreadV2Blocking`
- Add `UnspeccedGetPostThreadV2Request` (`anchor` / `above` / `below` / `branchingFactor` / `sort`)
- Add `UnspeccedGetPostThreadV2Response` (`thread: List<UnspeccedDefsThreadItem>` / `threadgate` / `hasOtherReplies`)
- New models under `model/app/bsky/unspecced/`:
  - `UnspeccedDefsThreadItem` (`uri` / `depth` / `value`)
  - `UnspeccedDefsThreadItemUnion` with `asPost` / `asNoUnauthenticated` / `asNotFound` / `asBlocked` accessors
  - `UnspeccedDefsThreadItemPost` / `UnspeccedDefsThreadItemNoUnauthenticated` / `UnspeccedDefsThreadItemNotFound` / `UnspeccedDefsThreadItemBlocked`
- `model/app/bsky/feed/FeedDefsBlockedAuthor.kt`: Add `app.bsky.feed.defs#blockedAuthor` (used by `threadItemBlocked`)
- `UnspeccedDefsThreadItemPolymorphicSerializer`: `JsonContentPolymorphicSerializer` that dispatches on `$type`, falling back to an `Unknown` member for unrecognized types (same pattern as the other union serializers)
- Tests: `GetPostThreadV2Test` (live)

## Notes
- The `threadItem.value` union follows the existing union pattern (`abstract class` + `@Serializable(with = ...)` + `as*` accessors), so consumers can do `item.value?.asPost?.post` and fall back on `asBlocked` / `asNotFound` / `asNoUnauthenticated`.
- `opThreadPostIndex` / `opThreadPostCount` are nullable because the AppView omits them for posts that are not part of the OP thread (`opThread = false`); the booleans default to `false` as in the lexicon.

## Test plan
- [x] `./gradlew :core:compileKotlinJvm` / `:core:compileTestKotlinJvm` compile without errors
- [x] `GetPostThreadV2Test` passes against the live AppView: a 10-post OP thread deserializes with `opThread = true` and `opThreadPostIndex` 1..7 / `opThreadPostCount = 10`, while other users' replies have `opThread = false` and null index / count; `hasOtherReplies` is populated
- [x] `above` / `below` / `branchingFactor` / `sort` parameters are honored against a live server
- [ ] `threadItemBlocked` / `threadItemNotFound` / `threadItemNoUnauthenticated` deserialize correctly on a real thread containing them

----

いわゆるスレッド番号表示の対応のために getPostThreadV2 を追加しました。

例によってZonePaneで動作確認済みです。

threadItemBlocked などは見当たらないので実データでのテストは行っていません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving post conversations through the unstable Post Thread V2 endpoint.
  * Responses include thread items, blocked or unavailable content states, threadgate information, reply availability, and conversation metadata.
  * Added asynchronous and blocking request options with configurable thread query parameters.
  * Added support for safely handling unrecognized thread item types.

* **Tests**
  * Added coverage for retrieving, deserializing, and inspecting Post Thread V2 results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->